### PR TITLE
added a secondary method get_dsp(...) and a struct to handle the data

### DIFF
--- a/NeuralAmpModeler/.editorconfig
+++ b/NeuralAmpModeler/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+indent_style = space
+indent_size = 2

--- a/NeuralAmpModeler/dsp/dsp.h
+++ b/NeuralAmpModeler/dsp/dsp.h
@@ -363,10 +363,10 @@ namespace convnet {
 // Implemented in get_dsp.cpp
 
 struct dspData {
-    std::string version;
-    std::string architecture;
-    nlohmann::json config;
-    std::vector<float> params;
+  std::string version;
+  std::string architecture;
+  nlohmann::json config;
+  std::vector<float> params;
 };
 
 // Verify that the config that we are building our model from is supported by

--- a/NeuralAmpModeler/dsp/dsp.h
+++ b/NeuralAmpModeler/dsp/dsp.h
@@ -11,6 +11,7 @@
 
 #include <Eigen/Dense>
 #include "IPlugConstants.h"
+#include "json.hpp"
 
 enum EArchitectures
 {
@@ -361,13 +362,23 @@ namespace convnet {
 // Utilities ==================================================================
 // Implemented in get_dsp.cpp
 
+struct dspData {
+    std::string version;
+    std::string architecture;
+    nlohmann::json config;
+    std::vector<float> params;
+};
+
 // Verify that the config that we are building our model from is supported by
 // this plugin version.
 void verify_config_version(const std::string version);
 
 // Takes the directory, finds the required files, and uses them to instantiate
-// an instance of DSP.
-std::unique_ptr<DSP> get_dsp(const std::filesystem::path dirname);
+// an instance of DSP. Also returns an dspData struct that holds the data of the model.
+std::unique_ptr<DSP> get_dsp(const std::filesystem::path dirname, dspData& returnedConfig);
+
+//Instantiates a DSP object from dsp_config struct. 
+std::unique_ptr<DSP> get_dsp(dspData& conf);
 
 // Hard-coded model:
 std::unique_ptr<DSP> get_hard_dsp();

--- a/NeuralAmpModeler/dsp/get_dsp.cpp
+++ b/NeuralAmpModeler/dsp/get_dsp.cpp
@@ -18,104 +18,105 @@ void verify_config_version(const std::string version)
 
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path dirname, dspData& returnedConfig)
 {
-    const std::filesystem::path config_filename = dirname / std::filesystem::path("config.json");
-    if (!std::filesystem::exists(config_filename))
-        throw std::runtime_error("Config JSON doesn't exist!\n");
-    std::ifstream i(config_filename);
-    nlohmann::json j;
-    i >> j;
-    
-    returnedConfig.version = j["version"];
-    returnedConfig.architecture = j["architecture"];
-    returnedConfig.config = j["config"];    
-    returnedConfig.params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
-    
-    /*Copy to a new dsp_config object for get_dsp below, 
-    since not sure if params actually get modified as being non-const references on some
-    model constructors inside get_dsp(dsp_config& conf). 
-    We need to return unmodified version of dsp_config via returnedConfig.*/
-    dspData conf = returnedConfig;
+  const std::filesystem::path config_filename = dirname / std::filesystem::path("config.json");
+  if (!std::filesystem::exists(config_filename))
+    throw std::runtime_error("Config JSON doesn't exist!\n");
+  std::ifstream i(config_filename);
+  nlohmann::json j;
+  i >> j;
+  verify_config_version(j["version"]);
 
-    return get_dsp(conf);
+  returnedConfig.version = j["version"];
+  returnedConfig.architecture = j["architecture"];
+  returnedConfig.config = j["config"];
+  returnedConfig.params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
+
+  /*Copy to a new dsp_config object for get_dsp below,
+  since not sure if params actually get modified as being non-const references on some
+  model constructors inside get_dsp(dsp_config& conf).
+  We need to return unmodified version of dsp_config via returnedConfig.*/
+  dspData conf = returnedConfig;
+
+  return get_dsp(conf);
 }
 
 std::unique_ptr<DSP> get_dsp(dspData& conf) {
 
-    verify_config_version(conf.version);
+  verify_config_version(conf.version);
 
-    auto architecture = conf.architecture;
-    nlohmann::json config = conf.config;
+  auto architecture = conf.architecture;
+  nlohmann::json config = conf.config;
 
-    if (architecture == "Linear")
-    {
-        const int receptive_field = config["receptive_field"];
-        const bool _bias = config["bias"];        
-        return std::make_unique<Linear>(receptive_field, _bias, conf.params);
+  if (architecture == "Linear")
+  {
+    const int receptive_field = config["receptive_field"];
+    const bool _bias = config["bias"];
+    return std::make_unique<Linear>(receptive_field, _bias, conf.params);
+  }
+  else if (architecture == "ConvNet")
+  {
+    const int channels = config["channels"];
+    const bool batchnorm = config["batchnorm"];
+    std::vector<int> dilations;
+    for (int i = 0; i < config["dilations"].size(); i++)
+      dilations.push_back(config["dilations"][i]);
+    const std::string activation = config["activation"];
+    return std::make_unique<convnet::ConvNet>(channels, dilations, batchnorm, activation, conf.params);
+  }
+  else if (architecture == "LSTM")
+  {
+    const int num_layers = config["num_layers"];
+    const int input_size = config["input_size"];
+    const int hidden_size = config["hidden_size"];
+    auto json = nlohmann::json{};
+    return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, conf.params, json);
+  }
+  else if (architecture == "CatLSTM")
+  {
+    const int num_layers = config["num_layers"];
+    const int input_size = config["input_size"];
+    const int hidden_size = config["hidden_size"];
+    return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, conf.params, config["parametric"]);
+  }
+  else if (architecture == "WaveNet" || architecture == "CatWaveNet")
+  {
+    std::vector<wavenet::LayerArrayParams> layer_array_params;
+    for (int i = 0; i < config["layers"].size(); i++) {
+      nlohmann::json layer_config = config["layers"][i];
+      std::vector<int> dilations;
+      for (int j = 0; j < layer_config["dilations"].size(); j++)
+        dilations.push_back(layer_config["dilations"][j]);
+      layer_array_params.push_back(
+        wavenet::LayerArrayParams(
+          layer_config["input_size"],
+          layer_config["condition_size"],
+          layer_config["head_size"],
+          layer_config["channels"],
+          layer_config["kernel_size"],
+          dilations,
+          layer_config["activation"],
+          layer_config["gated"],
+          layer_config["head_bias"]
+        )
+      );
     }
-    else if (architecture == "ConvNet")
-    {
-        const int channels = config["channels"];
-        const bool batchnorm = config["batchnorm"];
-        std::vector<int> dilations;
-        for (int i = 0; i < config["dilations"].size(); i++)
-            dilations.push_back(config["dilations"][i]);
-        const std::string activation = config["activation"];        
-        return std::make_unique<convnet::ConvNet>(channels, dilations, batchnorm, activation, conf.params);
-    }
-    else if (architecture == "LSTM")
-    {
-        const int num_layers = config["num_layers"];
-        const int input_size = config["input_size"];
-        const int hidden_size = config["hidden_size"];        
-        auto json = nlohmann::json{};
-        return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, conf.params, json);
-    }
-    else if (architecture == "CatLSTM")
-    {
-        const int num_layers = config["num_layers"];
-        const int input_size = config["input_size"];
-        const int hidden_size = config["hidden_size"];        
-        return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, conf.params, config["parametric"]);
-    }
-    else if (architecture == "WaveNet" || architecture == "CatWaveNet")
-    {
-        std::vector<wavenet::LayerArrayParams> layer_array_params;
-        for (int i = 0; i < config["layers"].size(); i++) {
-            nlohmann::json layer_config = config["layers"][i];
-            std::vector<int> dilations;
-            for (int j = 0; j < layer_config["dilations"].size(); j++)
-                dilations.push_back(layer_config["dilations"][j]);
-            layer_array_params.push_back(
-                wavenet::LayerArrayParams(
-                    layer_config["input_size"],
-                    layer_config["condition_size"],
-                    layer_config["head_size"],
-                    layer_config["channels"],
-                    layer_config["kernel_size"],
-                    dilations,
-                    layer_config["activation"],
-                    layer_config["gated"],
-                    layer_config["head_bias"]
-                )
-            );
-        }
-        const bool with_head = config["head"] == NULL;
-        const float head_scale = config["head_scale"];        
-        // Solves compilation issue on macOS Error: No matching constructor for initialization of 'wavenet::WaveNet'
-        // Solution from https://stackoverflow.com/a/73956681/3768284
-        auto parametric_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
-        return std::make_unique<wavenet::WaveNet>(
-            layer_array_params,
-            head_scale,
-            with_head,
-            parametric_json,
-            conf.params
-            );
-    }
-    else
-    {
-        throw std::runtime_error("Unrecognized architecture");
-    }
+    const bool with_head = config["head"] == NULL;
+    const float head_scale = config["head_scale"];
+    // Solves compilation issue on macOS Error: No matching constructor for initialization of 'wavenet::WaveNet'
+    // Solution from https://stackoverflow.com/a/73956681/3768284
+    auto parametric_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
+    return std::make_unique<wavenet::WaveNet>(
+      layer_array_params,
+      head_scale,
+      with_head,
+      parametric_json,
+      conf.params
+      );
+  }
+  else
+  {
+    throw std::runtime_error("Unrecognized architecture");
+  }
 }
 
 std::unique_ptr<DSP> get_hard_dsp()

--- a/NeuralAmpModeler/dsp/get_dsp.cpp
+++ b/NeuralAmpModeler/dsp/get_dsp.cpp
@@ -16,94 +16,106 @@ void verify_config_version(const std::string version)
     throw std::runtime_error("Unsupported config version");
 }
 
-std::unique_ptr<DSP> get_dsp(const std::filesystem::path dirname)
+std::unique_ptr<DSP> get_dsp(const std::filesystem::path dirname, dspData& returnedConfig)
 {
-  const std::filesystem::path config_filename = dirname / std::filesystem::path("config.json");
-  if (!std::filesystem::exists(config_filename))
-    throw std::runtime_error("Config JSON doesn't exist!\n");
-  std::ifstream i(config_filename);
-  nlohmann::json j;
-  i >> j;
-  verify_config_version(j["version"]);
+    const std::filesystem::path config_filename = dirname / std::filesystem::path("config.json");
+    if (!std::filesystem::exists(config_filename))
+        throw std::runtime_error("Config JSON doesn't exist!\n");
+    std::ifstream i(config_filename);
+    nlohmann::json j;
+    i >> j;
+    
+    returnedConfig.version = j["version"];
+    returnedConfig.architecture = j["architecture"];
+    returnedConfig.config = j["config"];    
+    returnedConfig.params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
+    
+    /*Copy to a new dsp_config object for get_dsp below, 
+    since not sure if params actually get modified as being non-const references on some
+    model constructors inside get_dsp(dsp_config& conf). 
+    We need to return unmodified version of dsp_config via returnedConfig.*/
+    dspData conf = returnedConfig;
 
-  auto architecture = j["architecture"];
-  nlohmann::json config = j["config"];
+    return get_dsp(conf);
+}
 
-  if (architecture == "Linear")
-  {
-    const int receptive_field = config["receptive_field"];
-    const bool _bias = config["bias"];
-    std::vector<float> params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
-    return std::make_unique<Linear>(receptive_field, _bias, params);
-  }
-  else if (architecture == "ConvNet")
-  {
-    const int channels = config["channels"];
-    const bool batchnorm = config["batchnorm"];
-    std::vector<int> dilations;
-    for (int i = 0; i < config["dilations"].size(); i++)
-      dilations.push_back(config["dilations"][i]);
-    const std::string activation = config["activation"];
-    std::vector<float> params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
-    return std::make_unique<convnet::ConvNet>(channels, dilations, batchnorm, activation, params);
-  }
-  else if (architecture == "LSTM")
-  {
-    const int num_layers = config["num_layers"];
-    const int input_size = config["input_size"];
-    const int hidden_size = config["hidden_size"];
-    std::vector<float> params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
-    auto json = nlohmann::json {};
-    return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, params, json);
-  }
-  else if (architecture == "CatLSTM")
-  {
-    const int num_layers = config["num_layers"];
-    const int input_size = config["input_size"];
-    const int hidden_size = config["hidden_size"];
-    std::vector<float> params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
-    return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, params, config["parametric"]);
-  }
-  else if (architecture == "WaveNet" || architecture == "CatWaveNet")
-  {
-    std::vector<wavenet::LayerArrayParams> layer_array_params;
-    for (int i = 0; i < config["layers"].size(); i++) {
-      nlohmann::json layer_config = config["layers"][i];
-      std::vector<int> dilations;
-      for (int j = 0; j < layer_config["dilations"].size(); j++)
-        dilations.push_back(layer_config["dilations"][j]);
-      layer_array_params.push_back(
-        wavenet::LayerArrayParams(
-          layer_config["input_size"],
-          layer_config["condition_size"],
-          layer_config["head_size"],
-          layer_config["channels"],
-          layer_config["kernel_size"],
-          dilations,
-          layer_config["activation"],
-          layer_config["gated"],
-          layer_config["head_bias"]
-        )
-      );
+std::unique_ptr<DSP> get_dsp(dspData& conf) {
+
+    verify_config_version(conf.version);
+
+    auto architecture = conf.architecture;
+    nlohmann::json config = conf.config;
+
+    if (architecture == "Linear")
+    {
+        const int receptive_field = config["receptive_field"];
+        const bool _bias = config["bias"];        
+        return std::make_unique<Linear>(receptive_field, _bias, conf.params);
     }
-    const bool with_head = config["head"] == NULL;
-    const float head_scale = config["head_scale"];
-    std::vector<float> params = numpy_util::load_to_vector(dirname / std::filesystem::path("weights.npy"));
-    // Solves compilation issue on macOS Error: No matching constructor for initialization of 'wavenet::WaveNet'
-    // Solution from https://stackoverflow.com/a/73956681/3768284
-    auto parametric_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
-    return std::make_unique<wavenet::WaveNet>(
-      layer_array_params,
-      head_scale,
-      with_head,
-      parametric_json,
-      params
-    );
-  }
-  else
-  {
-    throw std::runtime_error("Unrecognized architecture");
-  }
+    else if (architecture == "ConvNet")
+    {
+        const int channels = config["channels"];
+        const bool batchnorm = config["batchnorm"];
+        std::vector<int> dilations;
+        for (int i = 0; i < config["dilations"].size(); i++)
+            dilations.push_back(config["dilations"][i]);
+        const std::string activation = config["activation"];        
+        return std::make_unique<convnet::ConvNet>(channels, dilations, batchnorm, activation, conf.params);
+    }
+    else if (architecture == "LSTM")
+    {
+        const int num_layers = config["num_layers"];
+        const int input_size = config["input_size"];
+        const int hidden_size = config["hidden_size"];        
+        auto json = nlohmann::json{};
+        return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, conf.params, json);
+    }
+    else if (architecture == "CatLSTM")
+    {
+        const int num_layers = config["num_layers"];
+        const int input_size = config["input_size"];
+        const int hidden_size = config["hidden_size"];        
+        return std::make_unique<lstm::LSTM>(num_layers, input_size, hidden_size, conf.params, config["parametric"]);
+    }
+    else if (architecture == "WaveNet" || architecture == "CatWaveNet")
+    {
+        std::vector<wavenet::LayerArrayParams> layer_array_params;
+        for (int i = 0; i < config["layers"].size(); i++) {
+            nlohmann::json layer_config = config["layers"][i];
+            std::vector<int> dilations;
+            for (int j = 0; j < layer_config["dilations"].size(); j++)
+                dilations.push_back(layer_config["dilations"][j]);
+            layer_array_params.push_back(
+                wavenet::LayerArrayParams(
+                    layer_config["input_size"],
+                    layer_config["condition_size"],
+                    layer_config["head_size"],
+                    layer_config["channels"],
+                    layer_config["kernel_size"],
+                    dilations,
+                    layer_config["activation"],
+                    layer_config["gated"],
+                    layer_config["head_bias"]
+                )
+            );
+        }
+        const bool with_head = config["head"] == NULL;
+        const float head_scale = config["head_scale"];        
+        // Solves compilation issue on macOS Error: No matching constructor for initialization of 'wavenet::WaveNet'
+        // Solution from https://stackoverflow.com/a/73956681/3768284
+        auto parametric_json = architecture == "CatWaveNet" ? config["parametric"] : nlohmann::json{};
+        return std::make_unique<wavenet::WaveNet>(
+            layer_array_params,
+            head_scale,
+            with_head,
+            parametric_json,
+            conf.params
+            );
+    }
+    else
+    {
+        throw std::runtime_error("Unrecognized architecture");
+    }
 }
 
 std::unique_ptr<DSP> get_hard_dsp()


### PR DESCRIPTION
Hi!

Here's an (currently untested) addition to the repository. I'll use more effort on it if it looks promising. The idea is to split get_dsp function to be able to save, load and handle the model internally without the original json files. I find it convenient to be able to do this and opens up possibilities.