### PR TITLE
Better error messages for IR loader failures

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -10,6 +10,8 @@
 
 #include "ISender.h"
 
+#include "dsp/wav.h"
+
 const int kNumPresets = 1;
 
 enum EParams
@@ -68,7 +70,7 @@ private:
   // Gets a new DSP object and stores it to mStagedDSP
   void _GetDSP(const WDL_String& dspPath);
   // Gets the IR and stores to mStagedIR
-  void _GetIR(const WDL_String& irFileName);
+  dsp::wav::LoadReturnCode _GetIR(const WDL_String& irFileName);
   // Update the message about which model is loaded.
   void _SetModelMsg(const WDL_String& dspPath);
   bool _HaveModel() const {

--- a/NeuralAmpModeler/dsp/ImpulseResponse.cpp
+++ b/NeuralAmpModeler/dsp/ImpulseResponse.cpp
@@ -11,16 +11,18 @@
 #include "ImpulseResponse.h"
 
 dsp::ImpulseResponse::ImpulseResponse(const WDL_String& fileName,
-                                      const double sampleRate)
+                                      const double sampleRate):
+    mWavState(dsp::wav::LoadReturnCode::ERROR_OTHER)
 {
   // Try to load the WAV
-    if (dsp::wav::Load(fileName, this->mRawAudio, this->mRawAudioSampleRate) != dsp::wav::RET_SUCCESS) {
-        std::stringstream ss;
-        ss << "Failed to load IR at " << fileName.Get() << std::endl;
-        throw std::runtime_error(ss.str());
-    }
-  // Set the weights based on the raw audio.
-  this->_SetWeights(sampleRate);
+  this->mWavState = dsp::wav::Load(fileName, this->mRawAudio, this->mRawAudioSampleRate);
+  if (this->mWavState != dsp::wav::LoadReturnCode::SUCCESS) {
+    std::stringstream ss;
+    ss << "Failed to load IR at " << fileName.Get() << std::endl;
+  }
+  else
+    // Set the weights based on the raw audio.
+    this->_SetWeights(sampleRate);
 }
 
 iplug::sample** dsp::ImpulseResponse::Process(iplug::sample** inputs,

--- a/NeuralAmpModeler/dsp/ImpulseResponse.h
+++ b/NeuralAmpModeler/dsp/ImpulseResponse.h
@@ -16,6 +16,7 @@
 #include "wdlstring.h"  // WDL_String
 #include "IPlugConstants.h"  // sample
 #include "dsp.h"
+#include "wav.h"
 
 namespace dsp {
   class ImpulseResponse : public History {
@@ -24,10 +25,14 @@ namespace dsp {
     iplug::sample** Process(iplug::sample** inputs,
                             const size_t numChannels,
                             const size_t numFrames) override;
+    // TODO states for the IR class
+    dsp::wav::LoadReturnCode GetWavState() const { return this->mWavState; };
   private:
     // Set the weights, given that the plugin is running at the provided sample rate.
     void _SetWeights(const double sampleRate);
     
+    // State of audio
+    dsp::wav::LoadReturnCode mWavState;
     // Keep a copy of the raw audio that was loaded so that it can be resampled
     std::vector<float> mRawAudio;
     double mRawAudioSampleRate;

--- a/NeuralAmpModeler/dsp/wav.cpp
+++ b/NeuralAmpModeler/dsp/wav.cpp
@@ -80,7 +80,7 @@ int dsp::wav::Load(const WDL_String &fileName, std::vector<float> &audio, double
   wavFile.read(reinterpret_cast<char*>(&audioFormat), 2);
   if (audioFormat != 1) {
     std::cerr << "Error: Only PCM format is supported" << std::endl;
-    return dsp::wav::RET_ERROR_NOT_PCM;
+    return dsp::wav::RET_ERROR_NOT_PCM_OTHER;
   }
   
   short numChannels;

--- a/NeuralAmpModeler/dsp/wav.h
+++ b/NeuralAmpModeler/dsp/wav.h
@@ -17,7 +17,13 @@ namespace dsp {
     const int RET_ERROR_OPENING = 1;
     const int RET_ERROR_NOT_WAV = 2;
     const int RET_ERROR_INVALID_WAV = 3;
-    const int RET_ERROR_NOT_PCM = 4;
+    // Errors related to non-PCM formats:
+    // Format is "Extensible" instead of PCM
+    const int RET_ERROR_NOT_PCM_EXTENSIBLE = 4;
+    // IEEE float
+    const int RET_ERROR_NOT_PCM_IEEE_FLOAT = 5;
+    // Format is not PCM but something else
+    const int RET_ERROR_NOT_PCM_OTHER = 6;
     // Load a WAV file into a provided array of doubles,
     // And note the sample rate.
     //

--- a/NeuralAmpModeler/dsp/wav.h
+++ b/NeuralAmpModeler/dsp/wav.h
@@ -12,23 +12,26 @@
 
 namespace dsp {
   namespace wav {
-    // Return cases
-    const int RET_SUCCESS = 0;
-    const int RET_ERROR_OPENING = 1;
-    const int RET_ERROR_NOT_WAV = 2;
-    const int RET_ERROR_INVALID_WAV = 3;
-    // Errors related to non-PCM formats:
-    // Format is "Extensible" instead of PCM
-    const int RET_ERROR_NOT_PCM_EXTENSIBLE = 4;
-    // IEEE float
-    const int RET_ERROR_NOT_PCM_IEEE_FLOAT = 5;
-    // Format is not PCM but something else
-    const int RET_ERROR_NOT_PCM_OTHER = 6;
+    enum class LoadReturnCode {
+        SUCCESS = 0,
+        ERROR_OPENING,
+        ERROR_NOT_RIFF,
+        ERROR_NOT_WAVE,
+        ERROR_MISSING_FMT,
+        ERROR_INVALID_FILE,
+        ERROR_UNSUPPORTED_FORMAT_IEEE_FLOAT,
+        ERROR_UNSUPPORTED_FORMAT_ALAW,
+        ERROR_UNSUPPORTED_FORMAT_MULAW,
+        ERROR_UNSUPPORTED_FORMAT_EXTENSIBLE,
+        ERROR_UNSUPPORTED_BITS_PER_SAMPLE,
+        ERROR_NOT_MONO,
+        ERROR_OTHER
+    };
     // Load a WAV file into a provided array of doubles,
     // And note the sample rate.
     //
     // Returns: as per return cases above
-    int Load(const WDL_String& fileName, std::vector<float> &audio, double& sampleRate);
+    LoadReturnCode Load(const WDL_String& fileName, std::vector<float> &audio, double& sampleRate);
     
     // Load samples, 16-bit
     void _LoadSamples16(std::ifstream &wavFile, const int chunkSize, std::vector<float>& samples);


### PR DESCRIPTION
There are a lot of WAV file formats out there. An unsupported WAV file format is the most common failure. This PR make the plugin far more helpful with what went wrong.

Resolves #43 