### PR TITLE
Plugin works with VST3 SDK's VST3PluginTestHost

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -107,18 +107,21 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
   mInputPointers(nullptr),
   mOutputPointers(nullptr),
   mNAM(nullptr),
+  mIR(nullptr),
   mStagedNAM(nullptr),
-  mToneBass(),
-  mToneMid(),
-  mToneTreble(),
-  mIR(),
-  mNAMPath(),
-  mNAMLegacyPath(),
-  mIRPath(),
+  mStagedIR(nullptr),
   mFlagRemoveNAM(false),
   mFlagRemoveIR(false),
   mDefaultNAMString("Select model..."),
-  mDefaultIRString("Select IR...")
+  mDefaultIRString("Select IR..."),
+  mToneBass(),
+  mToneMid(),
+  mToneTreble(),
+  mNAMPath(),
+  mNAMLegacyPath(),
+  mIRPath(),
+  mInputSender(),
+  mOutputSender()
 {
   GetParam(kInputLevel)->InitGain("Input", 0.0, -20.0, 20.0, 0.1);
   GetParam(kToneBass)->InitDouble("Bass", 5.0, 0.0, 10.0, 0.1);
@@ -672,10 +675,14 @@ void NeuralAmpModeler::_PrepareBuffers(const int nFrames)
 
 void NeuralAmpModeler::_PrepareIOPointers(const size_t nChans)
 {
-  if (this->mInputPointers != nullptr)
+  if (this->mInputPointers != nullptr) {
     delete[] this->mInputPointers;
-  if (this->mOutputPointers != nullptr)
+    this->mInputPointers = nullptr;
+  }
+  if (this->mOutputPointers != nullptr) {
     delete[] this->mOutputPointers;
+    this->mOutputPointers = nullptr;
+  }
   this->mInputPointers = new sample*[nChans];
   if (this->mInputPointers == nullptr)
     throw std::runtime_error("Failed to allocate pointer to input buffer!\n");

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -125,6 +125,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
   GetParam(kToneMid)->InitDouble("Middle", 5.0, 0.0, 10.0, 0.1);
   GetParam(kToneTreble)->InitDouble("Treble", 5.0, 0.0, 10.0, 0.1);
   GetParam(kOutputLevel)->InitGain("Output", 0.0, -40.0, 40.0, 0.1);
+  GetParam(kEQActive)->InitBool("ToneStack", false);
 
 //  try {
 //     this->mDSP = get_hard_dsp();
@@ -307,7 +308,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     
     // The knobs
     pGraphics->AttachControl(new IVKnobControl(inputKnobArea, kInputLevel, "", style));
-    const bool toneStackIsActive = this->GetParam(kEQActive)->Value() > 0;
+    const bool toneStackIsActive = this->GetParam(kEQActive)->Value();
     const IVStyle toneStackInitialStyle = toneStackIsActive ? style : styleInactive;
     IVKnobControl* bassControl = new IVKnobControl(bassKnobArea, kToneBass, "", toneStackInitialStyle);
     IVKnobControl* middleControl = new IVKnobControl(middleKnobArea, kToneMid, "", toneStackInitialStyle);
@@ -406,7 +407,7 @@ void NeuralAmpModeler::ProcessBlock(iplug::sample** inputs, iplug::sample** outp
   this->_PrepareBuffers(nFrames);
   this->_ProcessInput(inputs, nFrames);
   this->_ApplyDSPStaging();
-  const bool toneStackActive = this->GetParam(kEQActive)->Value() > 0;
+  const bool toneStackActive = this->GetParam(kEQActive)->Value();
 
   if (mNAM != nullptr)
   {

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -88,13 +88,24 @@ private:
       return this->mNAM != nullptr;
   };
   // Prepare the input & output buffers
-  void _PrepareBuffers(const int nFrames);
+  void _PrepareBuffers(const size_t numChannels, const size_t numFrames);
   // Manage pointers
   void _PrepareIOPointers(const size_t nChans);
   // Copy the input buffer to the object, applying input level.
-  void _ProcessInput(iplug::sample** inputs, const int nFrames);
+  // :param nChansIn: In from external
+  // :param nChansOut: Out to the internal of the DSP routine
+  void _ProcessInput(iplug::sample** inputs,
+                     const size_t nFrames,
+                     const size_t nChansIn,
+                     const size_t nChansOut);
   // Copy the output to the output buffer, applying output level.
-  void _ProcessOutput(iplug::sample** inputs, iplug::sample** outputs, const int nFrames);
+  // :param nChansIn: In from internal
+  // :param nChansOut: Out to external
+  void _ProcessOutput(iplug::sample** inputs,
+                      iplug::sample** outputs,
+                      const size_t nFrames,
+                      const size_t nChansIn,
+                      const size_t nChansOut);
   // Update the text in the IR area to say what's loaded.
   void _SetIRMsg(const WDL_String& irPath);
   void _UnsetModelMsg();
@@ -103,9 +114,16 @@ private:
   // Update level meters
   // Called within ProcessBlock().
   // Assume _ProcessInput() and _ProcessOutput() were run immediately before.
-  void _UpdateMeters(iplug::sample** inputPointer, iplug::sample** outputPointer, const int nFrames);
+  void _UpdateMeters(iplug::sample** inputPointer,
+                     iplug::sample** outputPointer,
+                     const size_t nFrames,
+                     const size_t nChansIn,
+                     const size_t nChansOut);
 
   // Member data
+  
+  // The plugin is mono inside
+  const size_t mNUM_INTERNAL_CHANNELS = 1;
     
   // Input arrays to NAM
   std::vector<std::vector<iplug::sample>> mInputArray;

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -41,6 +41,7 @@ class NeuralAmpModeler final : public iplug::Plugin
 {
 public:
   NeuralAmpModeler(const iplug::InstanceInfo& info);
+  ~NeuralAmpModeler();
 
   void ProcessBlock(iplug::sample** inputs, iplug::sample** outputs, int nFrames) override;
   void OnReset() override {
@@ -58,11 +59,15 @@ public:
   void OnUIOpen() override;
   
 private:
+  // Allocates mInputPointers and mOutputPointers
+  void _AllocateIOPointers(const size_t nChans);
   // Moves DSP modules from staging area to the main area.
   // Also deletes DSP modules that are flagged for removal.
   // Exists so that we don't try to use a DSP module that's only
   // partially-instantiated.
   void _ApplyDSPStaging();
+  // Deallocates mInputPointers and mOutputPointers
+  void _DeallocateIOPointers();
   // Fallback that just copies inputs to outputs if mDSP doesn't hold a model.
   void _FallbackDSP(const int nFrames);
   // Sizes based on mInputArray

--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -46,7 +46,7 @@
 #define AAX_PLUG_CATEGORY_STR "Effect"
 #define AAX_DOES_AUDIOSUITE 1
 
-#define VST3_SUBCATEGORY "Effect"
+#define VST3_SUBCATEGORY "Fx"
 
 #define APP_NUM_CHANNELS 2
 #define APP_N_VECTOR_WAIT 0

--- a/NeuralAmpModeler/dsp/dsp.h
+++ b/NeuralAmpModeler/dsp/dsp.h
@@ -398,6 +398,12 @@ namespace dsp {
   protected:
     // Methods
     
+    // Allocate mOutputPointers.
+    // Assumes it's already null (Use _DeallocateOutputPointers()).
+    void _AllocateOutputPointers(const size_t numChannels);
+    // Ensure mOutputPointers is freed.
+    void _DeallocateOutputPointers();
+    
     size_t _GetNumChannels() const {return this->mOutputs.size();};
     // Return a pointer-to-pointers for the DSP's output buffers (all channels)
     // Assumes that ._PrepareBuffers()  was called recently enough.


### PR DESCRIPTION
Fixed issues causing unit tests to fail on the VST3 SDK VST3PluginTestHost unit test tool:
* Parameter for tone stack toggle wasn't properly initialized; initialized as bool

Fixed issue preventing the plugin from showing up in the list of VST3 plugins:
* `VST3_SUBCATEGORY` was defined as "Effect", changed to "Fx". (May fix Cubase issue.)

Other improvements:
* Distinguished between input and output channels; coerce main internal DSP to be in mono (since all effects are mono anyways).
* Improved some typing.
* Fixed a possible issue with too many channels being sent to the input & output meters.