### PR TITLE
Speed up wavenet activation tanh processing

### DIFF
--- a/NeuralAmpModeler/dsp/dsp.cpp
+++ b/NeuralAmpModeler/dsp/dsp.cpp
@@ -202,7 +202,16 @@ void tanh_(Eigen::MatrixXf &x, const long j_start, const long j_end) {
   tanh_(x, 0, x.rows(), j_start, j_end);
 }
 
-void tanh_(Eigen::MatrixXf &x) { tanh_(x, 0, x.rows(), 0, x.cols()); }
+void tanh_(Eigen::MatrixXf& x) {
+    float* ptr = x.data();
+
+    long size = x.rows() * x.cols();
+
+    for (long pos = 0; pos < size; pos++)
+    {
+        ptr[pos] = tanh(ptr[pos]);
+    }
+}
 
 void Conv1D::set_params_(std::vector<float>::iterator &params) {
   if (this->_weight.size() > 0) {

--- a/NeuralAmpModeler/dsp/wavenet.cpp
+++ b/NeuralAmpModeler/dsp/wavenet.cpp
@@ -30,7 +30,7 @@ void wavenet::_Layer::process_(const Eigen::MatrixXf &input,
   // Mix-in condition
   this->_z += this->_input_mixin.process(condition);
   if (this->_activation == "Tanh")
-    tanh_(this->_z, 0, channels, 0, this->_z.cols());
+    tanh_(this->_z);
   else if (this->_activation == "ReLU")
     relu_(this->_z, 0, channels, 0, this->_z.cols());
   else


### PR DESCRIPTION
This changes tanh processing on a whole matrix to operate directly on the data. It also uses this full matrix call in wavenet::_Layer::process_ to do activation processing.

Overall speed increase is about 20% on my machine (it goes from using approx 2.2% to 1.7% of my CPU as reported by Reaper).