### PR TITLE
Add math.h include for Linux compilation

### DIFF
--- a/NeuralAmpModeler/dsp/wavenet.cpp
+++ b/NeuralAmpModeler/dsp/wavenet.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <iostream>
+#include <math.h>
 
 #include <Eigen/Dense>
 


### PR DESCRIPTION
"math.h" is required to build the NAM dsp code on Linux. Adding it does not cause a problem on Windows.