### PR TITLE
Add fast tanh approximation

### DIFF
--- a/NeuralAmpModeler/dsp/dsp.cpp
+++ b/NeuralAmpModeler/dsp/dsp.cpp
@@ -12,6 +12,10 @@
 #include "numpy_util.h"
 #include "util.h"
 
+#define tanh_impl_ std::tanh
+//#define tanh_impl_ fast_tanh_
+
+
 constexpr auto _INPUT_BUFFER_SAFETY_FACTOR = 32;
 
 DSP::DSP() { this->_stale_params = true; }
@@ -191,11 +195,23 @@ void sigmoid_(Eigen::MatrixXf &x, const long i_start, const long i_end,
       x(i, j) = 1.0 / (1.0 + expf(-x(i, j)));
 }
 
+inline float fast_tanh_(const float x)
+{
+    const float ax = fabs(x);
+    const float x2 = x * x;
+
+    return(x * (2.45550750702956f + 2.45550750702956f * ax +
+        (0.893229853513558f + 0.821226666969744f * ax) * x2) /
+        (2.44506634652299f + (2.44506634652299f + x2) *
+            fabs(x + 0.814642734961073f * x * ax)));
+}
+
+
 void tanh_(Eigen::MatrixXf &x, const long i_start, const long i_end,
            const long j_start, const long j_end) {
   for (long j = j_start; j < j_end; j++)
     for (long i = i_start; i < i_end; i++)
-      x(i, j) = tanh(x(i, j));
+      x(i, j) = tanh_impl_(x(i, j));
 }
 
 void tanh_(Eigen::MatrixXf &x, const long j_start, const long j_end) {
@@ -203,13 +219,14 @@ void tanh_(Eigen::MatrixXf &x, const long j_start, const long j_end) {
 }
 
 void tanh_(Eigen::MatrixXf& x) {
+
     float* ptr = x.data();
 
     long size = x.rows() * x.cols();
 
     for (long pos = 0; pos < size; pos++)
     {
-        ptr[pos] = tanh(ptr[pos]);
+        ptr[pos] = tanh_impl_(ptr[pos]);
     }
 }
 


### PR DESCRIPTION
This change adds a fast, accurate tanh approximation. On my machine, it speeds up processing by about 40%.

Note that this change has the potential to alter the perceived sound of the plugin. It sounds the same to my ears, though, and the performance gain is very significant.

Because it is not a transparent change, I have left it off by default. To enable it, switch the #define for tanh_impl_ to the fast_tanh_ in dsp.cpp.

Maybe this could be switched based on a compile flag?