### PR TITLE
Provided dspData struct an additional get_dsp(...) -methods

### DIFF
--- a/NeuralAmpModeler/.editorconfig
+++ b/NeuralAmpModeler/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+indent_style = space
+indent_size = 2

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -734,7 +734,7 @@ void NeuralAmpModeler::_FallbackDSP(iplug::sample **inputs,
 std::string NeuralAmpModeler::_GetNAM(const WDL_String &modelPath) {
   WDL_String previousNAMPath = this->mNAMPath;
   try {
-    auto dspPath = std::filesystem::path(modelPath.Get());
+    auto dspPath = std::filesystem::path(modelPath.Get());    
     mStagedNAM = get_dsp(dspPath);
     this->_SetModelMsg(modelPath);
     this->mNAMPath = modelPath;

--- a/NeuralAmpModeler/dsp/dsp.h
+++ b/NeuralAmpModeler/dsp/dsp.h
@@ -11,6 +11,7 @@
 
 #include "IPlugConstants.h"
 #include <Eigen/Dense>
+#include "json.hpp"
 
 enum EArchitectures {
   kLinear = 0,
@@ -292,12 +293,24 @@ protected:
 // Utilities ==================================================================
 // Implemented in get_dsp.cpp
 
+struct dspData {
+  std::string version;
+  std::string architecture;
+  nlohmann::json config;
+  std::vector<float> params;
+};
+
 // Verify that the config that we are building our model from is supported by
 // this plugin version.
 void verify_config_version(const std::string version);
 
 // Takes the model file and uses it to instantiate an instance of DSP.
 std::unique_ptr<DSP> get_dsp(const std::filesystem::path model_file);
+// Creates an instance of DSP. Also returns a dspData struct that holds the data of the model.
+std::unique_ptr<DSP> get_dsp(const std::filesystem::path model_file, dspData& returnedConfig);
+// Instantiates a DSP object from dsp_config struct. 
+std::unique_ptr<DSP> get_dsp(dspData& conf);
+
 // Legacy loader for directory-type DSPs
 std::unique_ptr<DSP> get_dsp_legacy(const std::filesystem::path dirname);
 


### PR DESCRIPTION
#33 and #73:
Here's fixed and also up-to-date dspData struct and get_dsp()-methods for saving, (editing) and loading DSP's with. Project builds and seems to work properly.

for #94 there's .editorconfig included which helps format the code a bit and modern editors are compatible with this cool little feature, so indentation etc. some other formal styling can be adjusted with this file.