### PR TITLE
Fixed denormal code issue on mac

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -12,7 +12,7 @@
 #include "NeuralAmpModeler.h"
 #include "IPlug_include_in_plug_src.h"
 // clang-format on
-#include "architecture.hpp";
+#include "architecture.hpp"
 
 using namespace iplug;
 using namespace igraphics;

--- a/NeuralAmpModeler/architecture.hpp
+++ b/NeuralAmpModeler/architecture.hpp
@@ -3,6 +3,9 @@
 #ifndef ARCHITECTURE_HPP
 #define ARCHITECTURE_HPP
 
+#include <cfenv>
+#include <fenv.h>
+
 // check cpu architecture
 
 #if /* x86_64 */ \


### PR DESCRIPTION
This PR adds #includes required for the denormal code to compile on mac.

Build verified working with this PR.