### PR TITLE
Make sure __has_builtin is supported

### DIFF
--- a/NeuralAmpModeler/architecture.hpp
+++ b/NeuralAmpModeler/architecture.hpp
@@ -95,8 +95,10 @@ inline void disable_denormals() noexcept {
 			_mm_setcsr(_mm_getcsr() | 0x8040);
 		#endif
 	#elif defined(ARCH_ARM)
-		#if __has_builtin(__builtin_arm_set_fpscr) && __has_builtin(__builtin_arm_get_fpscr)
-			__builtin_arm_set_fpscr(__builtin_arm_get_fpscr() | (1 << 24));
+		#if defined __has_builtin
+			#if __has_builtin(__builtin_arm_set_fpscr) && __has_builtin(__builtin_arm_get_fpscr)
+				__builtin_arm_set_fpscr(__builtin_arm_get_fpscr() | (1 << 24));
+			#endif
 		#endif
 	#endif
 


### PR DESCRIPTION
This is just a safety check around "__has_builtin" in the denormal handling, as it does not seem to be supported on all ARM systems. No impact to currently supported platforms - but probably best to be safe for possible future build targets.