### PR TITLE
Normalize output loudness

### DIFF
--- a/NeuralAmpModeler/Colors.h
+++ b/NeuralAmpModeler/Colors.h
@@ -40,9 +40,9 @@ const iplug::igraphics::IColor
 // const iplug::igraphics::IColor MOUSEOVER = NAM_5.WithOpacity(0.3);
 
 // My 3 colors (purple)
-// const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);    // Smoky Black
+// const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);  // Smoky Black
 // const iplug::igraphics::IColor NAM_2(255, 115, 93, 120);  // Old Lavendar
-// const iplug::igraphics::IColor NAM_3(255, 189, 185, 196); // Lavendar Gray
+// const iplug::igraphics::IColor NAM_3(255, 189, 185, 196);  // Lavendar Gray
 // Alts
 // const iplug::igraphics::IColor NAM_2(255, 34, 39, 37);  // Charleston Green
 // const iplug::igraphics::IColor NAM_2(255, 114, 161, 229);  // Little Boy Blue
@@ -54,8 +54,7 @@ const iplug::igraphics::IColor
 // Blue mode
 const iplug::igraphics::IColor NAM_1(255, 29, 26, 31);    // Raisin Black
 const iplug::igraphics::IColor NAM_2(255, 80, 133, 232);  // Azure
-const iplug::igraphics::IColor NAM_3(255, 162, 178, 191); // Cadet Blue
-// Crayola
+const iplug::igraphics::IColor NAM_3(255, 162, 178, 191); // Cadet Blue Crayola
 // Alts
 // const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);  // Smoky Black
 // const iplug::igraphics::IColor NAM_2(255, 126, 188, 230);  // Camel

--- a/NeuralAmpModeler/Colors.h
+++ b/NeuralAmpModeler/Colors.h
@@ -40,9 +40,9 @@ const iplug::igraphics::IColor
 // const iplug::igraphics::IColor MOUSEOVER = NAM_5.WithOpacity(0.3);
 
 // My 3 colors (purple)
-const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);    // Smoky Black
-const iplug::igraphics::IColor NAM_2(255, 115, 93, 120);  // Old Lavendar
-const iplug::igraphics::IColor NAM_3(255, 189, 185, 196); // Lavendar Gray
+// const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);    // Smoky Black
+// const iplug::igraphics::IColor NAM_2(255, 115, 93, 120);  // Old Lavendar
+// const iplug::igraphics::IColor NAM_3(255, 189, 185, 196); // Lavendar Gray
 // Alts
 // const iplug::igraphics::IColor NAM_2(255, 34, 39, 37);  // Charleston Green
 // const iplug::igraphics::IColor NAM_2(255, 114, 161, 229);  // Little Boy Blue
@@ -52,9 +52,9 @@ const iplug::igraphics::IColor NAM_3(255, 189, 185, 196); // Lavendar Gray
 // Lavender Blue
 
 // Blue mode
-// const iplug::igraphics::IColor NAM_1(255, 29, 26, 31);    // Raisin Black
-// const iplug::igraphics::IColor NAM_2(255, 80, 133, 232);  // Azure
-// const iplug::igraphics::IColor NAM_3(255, 162, 178, 191); // Cadet Blue
+const iplug::igraphics::IColor NAM_1(255, 29, 26, 31);    // Raisin Black
+const iplug::igraphics::IColor NAM_2(255, 80, 133, 232);  // Azure
+const iplug::igraphics::IColor NAM_3(255, 162, 178, 191); // Cadet Blue
 // Crayola
 // Alts
 // const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);  // Smoky Black

--- a/NeuralAmpModeler/Colors.h
+++ b/NeuralAmpModeler/Colors.h
@@ -40,9 +40,9 @@ const iplug::igraphics::IColor
 // const iplug::igraphics::IColor MOUSEOVER = NAM_5.WithOpacity(0.3);
 
 // My 3 colors (purple)
-// const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);  // Smoky Black
-// const iplug::igraphics::IColor NAM_2(255, 115, 93, 120);  // Old Lavendar
-// const iplug::igraphics::IColor NAM_3(255, 189, 185, 196);  // Lavendar Gray
+const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);    // Smoky Black
+const iplug::igraphics::IColor NAM_2(255, 115, 93, 120);  // Old Lavendar
+const iplug::igraphics::IColor NAM_3(255, 189, 185, 196); // Lavendar Gray
 // Alts
 // const iplug::igraphics::IColor NAM_2(255, 34, 39, 37);  // Charleston Green
 // const iplug::igraphics::IColor NAM_2(255, 114, 161, 229);  // Little Boy Blue
@@ -52,9 +52,10 @@ const iplug::igraphics::IColor
 // Lavender Blue
 
 // Blue mode
-const iplug::igraphics::IColor NAM_1(255, 29, 26, 31);    // Raisin Black
-const iplug::igraphics::IColor NAM_2(255, 80, 133, 232);  // Azure
-const iplug::igraphics::IColor NAM_3(255, 162, 178, 191); // Cadet Blue Crayola
+// const iplug::igraphics::IColor NAM_1(255, 29, 26, 31);    // Raisin Black
+// const iplug::igraphics::IColor NAM_2(255, 80, 133, 232);  // Azure
+// const iplug::igraphics::IColor NAM_3(255, 162, 178, 191); // Cadet Blue
+// Crayola
 // Alts
 // const iplug::igraphics::IColor NAM_1(255, 18, 17, 19);  // Smoky Black
 // const iplug::igraphics::IColor NAM_2(255, 126, 188, 230);  // Camel

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -114,6 +114,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo &info)
       ->InitGain("Gate", -80.0, -100.0, 0.0, 0.1);
   this->GetParam(kNoiseGateActive)->InitBool("NoiseGateActive", true);
   this->GetParam(kEQActive)->InitBool("ToneStack", true);
+  this->GetParam(kOutNorm)->InitBool("OutNorm", false);
 
   this->mNoiseGateTrigger.AddListener(&this->mNoiseGateGain);
 
@@ -169,8 +170,9 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo &info)
     const IRECT outputKnobArea = knobs.GetGridCell(0, kOutputLevel, 1, numKnobs)
                                      .GetPadded(-singleKnobPad);
 
-    // Area for EQ toggle
-    const float ngAreaHeight = 40.0f;
+    const float toggleHeight = 40.0f;
+    // Area for noise gate toggle
+    const float ngAreaHeight = toggleHeight;
     const float ngAreaHalfWidth = 0.5f * noiseGateArea.W();
     const IRECT ngToggleArea =
         noiseGateArea.GetFromBottom(ngAreaHeight)
@@ -178,12 +180,20 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo &info)
             .GetMidHPadded(ngAreaHalfWidth);
 
     // Area for EQ toggle
-    const float eqAreaHeight = 40.0f;
+    const float eqAreaHeight = toggleHeight;
     const float eqAreaHalfWidth = 0.5f * middleKnobArea.W();
     const IRECT eqToggleArea =
         middleKnobArea.GetFromBottom(eqAreaHeight)
             .GetTranslated(0.0f, eqAreaHeight + singleKnobPad)
             .GetMidHPadded(eqAreaHalfWidth);
+
+    // Area for output normalization toggle
+    const float outNormAreaHeight = toggleHeight;
+    const float outNormAreaHalfWidth = 0.5f * outputKnobArea.W();
+    const IRECT outNormToggleArea =
+        outputKnobArea.GetFromBottom(outNormAreaHeight)
+        .GetTranslated(0.0f, outNormAreaHeight + singleKnobPad)
+        .GetMidHPadded(outNormAreaHalfWidth);
 
     // Areas for model and IR
     const float fileWidth = 250.0f;
@@ -359,6 +369,12 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo &info)
                                  true, // valueInButton
                                  EDirection::Horizontal);
     pGraphics->AttachControl(toneStackSlider);
+    // NG toggle
+    IVSlideSwitchControl* outputNormSlider =
+        new IVSlideSwitchControl(outNormToggleArea, kOutNorm, "Normalize", style,
+            true, // valueInButton
+            EDirection::Horizontal);
+    pGraphics->AttachControl(outputNormSlider);
 
     // The knobs
     // Input
@@ -563,6 +579,7 @@ void NeuralAmpModeler::ProcessBlock(iplug::sample **inputs,
   }
 
   if (mNAM != nullptr) {
+    mNAM->SetNormalize(this->GetParam(kOutNorm)->Value());
     // TODO remove input / output gains from here.
     const double inputGain = 1.0;
     const double outputGain = 1.0;

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -192,8 +192,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo &info)
     const float outNormAreaHalfWidth = 0.5f * outputKnobArea.W();
     const IRECT outNormToggleArea =
         outputKnobArea.GetFromBottom(outNormAreaHeight)
-        .GetTranslated(0.0f, outNormAreaHeight + singleKnobPad)
-        .GetMidHPadded(outNormAreaHalfWidth);
+            .GetTranslated(0.0f, outNormAreaHeight + singleKnobPad)
+            .GetMidHPadded(outNormAreaHalfWidth);
 
     // Areas for model and IR
     const float fileWidth = 250.0f;
@@ -370,10 +370,10 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo &info)
                                  EDirection::Horizontal);
     pGraphics->AttachControl(toneStackSlider);
     // NG toggle
-    IVSlideSwitchControl* outputNormSlider =
-        new IVSlideSwitchControl(outNormToggleArea, kOutNorm, "Normalize", style,
-            true, // valueInButton
-            EDirection::Horizontal);
+    IVSlideSwitchControl *outputNormSlider = new IVSlideSwitchControl(
+        outNormToggleArea, kOutNorm, "Normalize", style,
+        true, // valueInButton
+        EDirection::Horizontal);
     pGraphics->AttachControl(outputNormSlider);
 
     // The knobs

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -786,7 +786,7 @@ dsp::wav::LoadReturnCode NeuralAmpModeler::_GetIR(const WDL_String &irPath) {
   dsp::wav::LoadReturnCode wavState = dsp::wav::LoadReturnCode::ERROR_OTHER;
   try {
     this->mStagedIR =
-        std::make_unique<dsp::ImpulseResponse>(irPath, sampleRate);
+        std::make_unique<dsp::ImpulseResponse>(irPath.Get(), sampleRate);
     wavState = this->mStagedIR->GetWavState();
   } catch (std::exception &e) {
     wavState = dsp::wav::LoadReturnCode::ERROR_OTHER;

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -23,6 +23,7 @@ enum EParams {
   // The rest is fine though.
   kNoiseGateActive,
   kEQActive,
+  kOutNorm,
   kNumParams
 };
 

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "NeuralAmpModelerCore/NAM/dsp.h"
 #include "NeuralAmpModelerCore/dsp/ImpulseResponse.h"
 #include "NeuralAmpModelerCore/dsp/NoiseGate.h"
 #include "NeuralAmpModelerCore/dsp/RecursiveLinearFilter.h"

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj
@@ -410,17 +410,31 @@
     <ClCompile Include="..\..\iPlug2\IPlug\IPlugProcessor.cpp" />
     <ClCompile Include="..\..\iPlug2\IPlug\IPlugTimer.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\cnpy.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\get_dsp.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\lstm.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\NoiseGate.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\numpy_util.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\util.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\wav.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\wavenet.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\convnet.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\dsp.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\get_dsp.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\lstm.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\util.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\wavenet.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuildStep Include="..\..\AAX_SDK\Libs\Release\AAXLibrary.lib">
@@ -503,19 +517,19 @@
     <ClInclude Include="..\Colors.h" />
     <ClInclude Include="..\config.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\activations.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\cnpy.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\dsp.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\lstm.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\NoiseGate.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\numpy_util.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\Resample.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\util.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\version.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\wav.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\wavenet.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\wavenet.h" />
     <ClInclude Include="..\resources\resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj.filters
@@ -58,40 +58,40 @@
     <ClCompile Include="..\..\iPlug2\IGraphics\Drawing\IGraphicsSkia.cpp">
       <Filter>IGraphics\Drawing</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\cnpy.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\get_dsp.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\lstm.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\NoiseGate.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\numpy_util.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\util.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\wav.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\wavenet.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\convnet.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\dsp.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\get_dsp.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\lstm.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\util.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\wavenet.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\resources\resource.h">
@@ -241,25 +241,13 @@
     <ClInclude Include="..\..\iPlug2\IGraphics\Drawing\IGraphicsSkia.h">
       <Filter>IGraphics\Drawing</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\activations.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\cnpy.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\dsp.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\lstm.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\NoiseGate.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\numpy_util.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.h">
@@ -268,21 +256,33 @@
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\Resample.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\util.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\version.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\wav.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\wavenet.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\Colors.h" />
     <ClInclude Include="..\config.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\wavenet.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="resources">
@@ -311,6 +311,9 @@
     </Filter>
     <Filter Include="dsp">
       <UniqueIdentifier>{6a256439-d389-4777-8f93-a14fe677139f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="NAM">
+      <UniqueIdentifier>{eeb1d689-b2e9-48ff-b191-358821a60f70}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
@@ -319,19 +319,19 @@
     <ClInclude Include="..\..\iPlug2\IPlug\IPlug_include_in_plug_src.h" />
     <ClInclude Include="..\Colors.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\activations.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\cnpy.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\dsp.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\lstm.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\NoiseGate.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\numpy_util.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\Resample.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\util.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\version.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\wav.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\wavenet.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\wavenet.h" />
     <ClInclude Include="..\resources\resource.h" />
   </ItemGroup>
   <ItemGroup>
@@ -375,17 +375,31 @@
     <ClCompile Include="..\..\iPlug2\IPlug\IPlugProcessor.cpp" />
     <ClCompile Include="..\..\iPlug2\IPlug\IPlugTimer.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\cnpy.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\get_dsp.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\lstm.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\NoiseGate.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\numpy_util.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\util.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\wav.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\wavenet.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\convnet.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\dsp.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\get_dsp.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\lstm.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\util.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\wavenet.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\resources\main.rc" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj.filters
@@ -77,38 +77,38 @@
     <ClCompile Include="..\..\iPlug2\IGraphics\Drawing\IGraphicsSkia.cpp">
       <Filter>IGraphics\Drawing</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\cnpy.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\get_dsp.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\lstm.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\NoiseGate.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\numpy_util.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\util.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\wav.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\wavenet.cpp">
-      <Filter>dsp</Filter>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\convnet.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\dsp.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\get_dsp.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\lstm.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\util.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\wavenet.cpp">
+      <Filter>NAM</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -292,25 +292,13 @@
       <Filter>IGraphics</Filter>
     </ClInclude>
     <ClInclude Include="..\Colors.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\activations.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\cnpy.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\dsp.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\lstm.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\NoiseGate.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\numpy_util.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.h">
@@ -319,17 +307,29 @@
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\Resample.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\util.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\version.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\wav.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\wavenet.h">
-      <Filter>dsp</Filter>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\wavenet.h">
+      <Filter>NAM</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -365,6 +365,9 @@
     </Filter>
     <Filter Include="dsp">
       <UniqueIdentifier>{8cc22245-ce8e-453b-b72f-b30ab0152cc3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="NAM">
+      <UniqueIdentifier>{3adb1e7a-68f8-4b41-8563-9bcf2bb0c8da}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-iOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-iOS.xcodeproj/project.pbxproj
@@ -64,47 +64,47 @@
 		AA63406229C54D4D00550809 /* RecursiveLinearFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404829C54D4B00550809 /* RecursiveLinearFilter.cpp */; };
 		AA63406329C54D4D00550809 /* RecursiveLinearFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404829C54D4B00550809 /* RecursiveLinearFilter.cpp */; };
 		AA63406429C54D4D00550809 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63404929C54D4B00550809 /* dsp.h */; };
-		AA63406529C54D4D00550809 /* lstm.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63404A29C54D4B00550809 /* lstm.h */; };
 		AA63406629C54D4D00550809 /* RecursiveLinearFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63404B29C54D4B00550809 /* RecursiveLinearFilter.h */; };
-		AA63406729C54D4D00550809 /* numpy_util.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63404C29C54D4B00550809 /* numpy_util.h */; };
-		AA63406829C54D4D00550809 /* activations.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63404D29C54D4B00550809 /* activations.h */; };
-		AA63406929C54D4D00550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404E29C54D4B00550809 /* wavenet.cpp */; };
-		AA63406A29C54D4D00550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404E29C54D4B00550809 /* wavenet.cpp */; };
-		AA63406B29C54D4D00550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404E29C54D4B00550809 /* wavenet.cpp */; };
-		AA63406C29C54D4D00550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404F29C54D4B00550809 /* numpy_util.cpp */; };
-		AA63406D29C54D4D00550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404F29C54D4B00550809 /* numpy_util.cpp */; };
-		AA63406E29C54D4D00550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63404F29C54D4B00550809 /* numpy_util.cpp */; };
-		AA63406F29C54D4D00550809 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405029C54D4B00550809 /* wavenet.h */; };
 		AA63407029C54D4D00550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405129C54D4B00550809 /* wav.cpp */; };
 		AA63407129C54D4D00550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405129C54D4B00550809 /* wav.cpp */; };
 		AA63407229C54D4D00550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405129C54D4B00550809 /* wav.cpp */; };
 		AA63407429C54D4D00550809 /* NoiseGate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405329C54D4C00550809 /* NoiseGate.h */; };
-		AA63407529C54D4D00550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405429C54D4C00550809 /* lstm.cpp */; };
-		AA63407629C54D4D00550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405429C54D4C00550809 /* lstm.cpp */; };
-		AA63407729C54D4D00550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405429C54D4C00550809 /* lstm.cpp */; };
-		AA63407829C54D4D00550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405529C54D4C00550809 /* util.cpp */; };
-		AA63407929C54D4D00550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405529C54D4C00550809 /* util.cpp */; };
-		AA63407A29C54D4D00550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405529C54D4C00550809 /* util.cpp */; };
 		AA63407B29C54D4D00550809 /* NoiseGate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405629C54D4C00550809 /* NoiseGate.cpp */; };
 		AA63407C29C54D4D00550809 /* NoiseGate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405629C54D4C00550809 /* NoiseGate.cpp */; };
 		AA63407D29C54D4D00550809 /* NoiseGate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405629C54D4C00550809 /* NoiseGate.cpp */; };
-		AA63407E29C54D4D00550809 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405729C54D4C00550809 /* util.h */; };
 		AA63407F29C54D4D00550809 /* wav.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405829C54D4C00550809 /* wav.h */; };
-		AA63408029C54D4D00550809 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405929C54D4C00550809 /* version.h */; };
-		AA63408129C54D4D00550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405A29C54D4C00550809 /* cnpy.cpp */; };
-		AA63408229C54D4D00550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405A29C54D4C00550809 /* cnpy.cpp */; };
-		AA63408329C54D4D00550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405A29C54D4C00550809 /* cnpy.cpp */; };
 		AA63408429C54D4D00550809 /* ImpulseResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405B29C54D4C00550809 /* ImpulseResponse.cpp */; };
 		AA63408529C54D4D00550809 /* ImpulseResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405B29C54D4C00550809 /* ImpulseResponse.cpp */; };
 		AA63408629C54D4D00550809 /* ImpulseResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405B29C54D4C00550809 /* ImpulseResponse.cpp */; };
-		AA63408729C54D4D00550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405C29C54D4C00550809 /* get_dsp.cpp */; };
-		AA63408829C54D4D00550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405C29C54D4C00550809 /* get_dsp.cpp */; };
-		AA63408929C54D4D00550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405C29C54D4C00550809 /* get_dsp.cpp */; };
 		AA63408A29C54D4D00550809 /* ImpulseResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405D29C54D4C00550809 /* ImpulseResponse.h */; };
 		AA63408B29C54D4D00550809 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405E29C54D4C00550809 /* dsp.cpp */; };
 		AA63408C29C54D4D00550809 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405E29C54D4C00550809 /* dsp.cpp */; };
 		AA63408D29C54D4D00550809 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA63405E29C54D4C00550809 /* dsp.cpp */; };
-		AA63408E29C54D4D00550809 /* cnpy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA63405F29C54D4D00550809 /* cnpy.h */; };
+		AAB1D0EB29E1026800EAAFE1 /* activations.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0DF29E1026700EAAFE1 /* activations.h */; };
+		AAB1D0EC29E1026800EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E729E1026700EAAFE1 /* convnet.cpp */; };
+		AAB1D0ED29E1026800EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E729E1026700EAAFE1 /* convnet.cpp */; };
+		AAB1D0EE29E1026800EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E729E1026700EAAFE1 /* convnet.cpp */; };
+		AAB1D0EF29E1026800EAAFE1 /* convnet.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0E029E1026700EAAFE1 /* convnet.h */; };
+		AAB1D0F029E1026800EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E829E1026700EAAFE1 /* dsp.cpp */; };
+		AAB1D0F129E1026800EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E829E1026700EAAFE1 /* dsp.cpp */; };
+		AAB1D0F229E1026800EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E829E1026700EAAFE1 /* dsp.cpp */; };
+		AAB1D0F329E1026800EAAFE1 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0E929E1026800EAAFE1 /* dsp.h */; };
+		AAB1D0F429E1026800EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E129E1026700EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0F529E1026800EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E129E1026700EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0F629E1026800EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E129E1026700EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0F729E1026800EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E529E1026700EAAFE1 /* lstm.cpp */; };
+		AAB1D0F829E1026800EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E529E1026700EAAFE1 /* lstm.cpp */; };
+		AAB1D0F929E1026800EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E529E1026700EAAFE1 /* lstm.cpp */; };
+		AAB1D0FA29E1026800EAAFE1 /* lstm.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0E329E1026700EAAFE1 /* lstm.h */; };
+		AAB1D0FB29E1026800EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0DE29E1026700EAAFE1 /* util.cpp */; };
+		AAB1D0FC29E1026800EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0DE29E1026700EAAFE1 /* util.cpp */; };
+		AAB1D0FD29E1026800EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0DE29E1026700EAAFE1 /* util.cpp */; };
+		AAB1D0FE29E1026800EAAFE1 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0E429E1026700EAAFE1 /* util.h */; };
+		AAB1D0FF29E1026800EAAFE1 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0EA29E1026800EAAFE1 /* version.h */; };
+		AAB1D10029E1026800EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E229E1026700EAAFE1 /* wavenet.cpp */; };
+		AAB1D10129E1026800EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E229E1026700EAAFE1 /* wavenet.cpp */; };
+		AAB1D10229E1026800EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D0E229E1026700EAAFE1 /* wavenet.cpp */; };
+		AAB1D10329E1026800EAAFE1 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D0E629E1026700EAAFE1 /* wavenet.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -333,27 +333,27 @@
 		AA63404729C54D4B00550809 /* Resample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Resample.h; path = ../NeuralAmpModelerCore/dsp/Resample.h; sourceTree = "<group>"; };
 		AA63404829C54D4B00550809 /* RecursiveLinearFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RecursiveLinearFilter.cpp; path = ../NeuralAmpModelerCore/dsp/RecursiveLinearFilter.cpp; sourceTree = "<group>"; };
 		AA63404929C54D4B00550809 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dsp.h; path = ../NeuralAmpModelerCore/dsp/dsp.h; sourceTree = "<group>"; };
-		AA63404A29C54D4B00550809 /* lstm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lstm.h; path = ../NeuralAmpModelerCore/dsp/lstm.h; sourceTree = "<group>"; };
 		AA63404B29C54D4B00550809 /* RecursiveLinearFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RecursiveLinearFilter.h; path = ../NeuralAmpModelerCore/dsp/RecursiveLinearFilter.h; sourceTree = "<group>"; };
-		AA63404C29C54D4B00550809 /* numpy_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = numpy_util.h; path = ../NeuralAmpModelerCore/dsp/numpy_util.h; sourceTree = "<group>"; };
-		AA63404D29C54D4B00550809 /* activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = activations.h; path = ../NeuralAmpModelerCore/dsp/activations.h; sourceTree = "<group>"; };
-		AA63404E29C54D4B00550809 /* wavenet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wavenet.cpp; path = ../NeuralAmpModelerCore/dsp/wavenet.cpp; sourceTree = "<group>"; };
-		AA63404F29C54D4B00550809 /* numpy_util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = numpy_util.cpp; path = ../NeuralAmpModelerCore/dsp/numpy_util.cpp; sourceTree = "<group>"; };
-		AA63405029C54D4B00550809 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wavenet.h; path = ../NeuralAmpModelerCore/dsp/wavenet.h; sourceTree = "<group>"; };
 		AA63405129C54D4B00550809 /* wav.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wav.cpp; path = ../NeuralAmpModelerCore/dsp/wav.cpp; sourceTree = "<group>"; };
 		AA63405329C54D4C00550809 /* NoiseGate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NoiseGate.h; path = ../NeuralAmpModelerCore/dsp/NoiseGate.h; sourceTree = "<group>"; };
-		AA63405429C54D4C00550809 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lstm.cpp; path = ../NeuralAmpModelerCore/dsp/lstm.cpp; sourceTree = "<group>"; };
-		AA63405529C54D4C00550809 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = ../NeuralAmpModelerCore/dsp/util.cpp; sourceTree = "<group>"; };
 		AA63405629C54D4C00550809 /* NoiseGate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NoiseGate.cpp; path = ../NeuralAmpModelerCore/dsp/NoiseGate.cpp; sourceTree = "<group>"; };
-		AA63405729C54D4C00550809 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = util.h; path = ../NeuralAmpModelerCore/dsp/util.h; sourceTree = "<group>"; };
 		AA63405829C54D4C00550809 /* wav.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wav.h; path = ../NeuralAmpModelerCore/dsp/wav.h; sourceTree = "<group>"; };
-		AA63405929C54D4C00550809 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../NeuralAmpModelerCore/dsp/version.h; sourceTree = "<group>"; };
-		AA63405A29C54D4C00550809 /* cnpy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cnpy.cpp; path = ../NeuralAmpModelerCore/dsp/cnpy.cpp; sourceTree = "<group>"; };
 		AA63405B29C54D4C00550809 /* ImpulseResponse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ImpulseResponse.cpp; path = ../NeuralAmpModelerCore/dsp/ImpulseResponse.cpp; sourceTree = "<group>"; };
-		AA63405C29C54D4C00550809 /* get_dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = get_dsp.cpp; path = ../NeuralAmpModelerCore/dsp/get_dsp.cpp; sourceTree = "<group>"; };
 		AA63405D29C54D4C00550809 /* ImpulseResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImpulseResponse.h; path = ../NeuralAmpModelerCore/dsp/ImpulseResponse.h; sourceTree = "<group>"; };
 		AA63405E29C54D4C00550809 /* dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dsp.cpp; path = ../NeuralAmpModelerCore/dsp/dsp.cpp; sourceTree = "<group>"; };
-		AA63405F29C54D4D00550809 /* cnpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cnpy.h; path = ../NeuralAmpModelerCore/dsp/cnpy.h; sourceTree = "<group>"; };
+		AAB1D0DE29E1026700EAAFE1 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = ../../NeuralAmpModelerCore/NAM/util.cpp; sourceTree = "<group>"; };
+		AAB1D0DF29E1026700EAAFE1 /* activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = activations.h; path = ../../NeuralAmpModelerCore/NAM/activations.h; sourceTree = "<group>"; };
+		AAB1D0E029E1026700EAAFE1 /* convnet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = convnet.h; path = ../../NeuralAmpModelerCore/NAM/convnet.h; sourceTree = "<group>"; };
+		AAB1D0E129E1026700EAAFE1 /* get_dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = get_dsp.cpp; path = ../../NeuralAmpModelerCore/NAM/get_dsp.cpp; sourceTree = "<group>"; };
+		AAB1D0E229E1026700EAAFE1 /* wavenet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wavenet.cpp; path = ../../NeuralAmpModelerCore/NAM/wavenet.cpp; sourceTree = "<group>"; };
+		AAB1D0E329E1026700EAAFE1 /* lstm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lstm.h; path = ../../NeuralAmpModelerCore/NAM/lstm.h; sourceTree = "<group>"; };
+		AAB1D0E429E1026700EAAFE1 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = util.h; path = ../../NeuralAmpModelerCore/NAM/util.h; sourceTree = "<group>"; };
+		AAB1D0E529E1026700EAAFE1 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lstm.cpp; path = ../../NeuralAmpModelerCore/NAM/lstm.cpp; sourceTree = "<group>"; };
+		AAB1D0E629E1026700EAAFE1 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wavenet.h; path = ../../NeuralAmpModelerCore/NAM/wavenet.h; sourceTree = "<group>"; };
+		AAB1D0E729E1026700EAAFE1 /* convnet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convnet.cpp; path = ../../NeuralAmpModelerCore/NAM/convnet.cpp; sourceTree = "<group>"; };
+		AAB1D0E829E1026700EAAFE1 /* dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dsp.cpp; path = ../../NeuralAmpModelerCore/NAM/dsp.cpp; sourceTree = "<group>"; };
+		AAB1D0E929E1026800EAAFE1 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dsp.h; path = ../../NeuralAmpModelerCore/NAM/dsp.h; sourceTree = "<group>"; };
+		AAB1D0EA29E1026800EAAFE1 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../../NeuralAmpModelerCore/NAM/version.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -636,30 +636,17 @@
 		4FBFBA2B29B115F700D1EA89 /* dsp */ = {
 			isa = PBXGroup;
 			children = (
-				AA63404D29C54D4B00550809 /* activations.h */,
-				AA63405A29C54D4C00550809 /* cnpy.cpp */,
-				AA63405F29C54D4D00550809 /* cnpy.h */,
 				AA63405E29C54D4C00550809 /* dsp.cpp */,
 				AA63404929C54D4B00550809 /* dsp.h */,
-				AA63405C29C54D4C00550809 /* get_dsp.cpp */,
 				AA63405B29C54D4C00550809 /* ImpulseResponse.cpp */,
 				AA63405D29C54D4C00550809 /* ImpulseResponse.h */,
-				AA63405429C54D4C00550809 /* lstm.cpp */,
-				AA63404A29C54D4B00550809 /* lstm.h */,
 				AA63405629C54D4C00550809 /* NoiseGate.cpp */,
 				AA63405329C54D4C00550809 /* NoiseGate.h */,
-				AA63404F29C54D4B00550809 /* numpy_util.cpp */,
-				AA63404C29C54D4B00550809 /* numpy_util.h */,
 				AA63404829C54D4B00550809 /* RecursiveLinearFilter.cpp */,
 				AA63404B29C54D4B00550809 /* RecursiveLinearFilter.h */,
 				AA63404729C54D4B00550809 /* Resample.h */,
-				AA63405529C54D4C00550809 /* util.cpp */,
-				AA63405729C54D4C00550809 /* util.h */,
-				AA63405929C54D4C00550809 /* version.h */,
 				AA63405129C54D4B00550809 /* wav.cpp */,
 				AA63405829C54D4C00550809 /* wav.h */,
-				AA63404E29C54D4B00550809 /* wavenet.cpp */,
-				AA63405029C54D4B00550809 /* wavenet.h */,
 			);
 			name = dsp;
 			path = ../dsp;
@@ -748,6 +735,7 @@
 				4FFF108820A1036200D3092F /* NeuralAmpModeler.h */,
 				4FFF108720A1036200D3092F /* NeuralAmpModeler.cpp */,
 				4F8D8BD82316701900EFA1FB /* README.md */,
+				AAB1D0DD29E1026700EAAFE1 /* NAM */,
 				4FBFBA2B29B115F700D1EA89 /* dsp */,
 				4F8BF48D20A12D2E0081DF0A /* Resources */,
 				4F67D51620A121F60061FB8E /* Other Sources */,
@@ -766,6 +754,26 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		AAB1D0DD29E1026700EAAFE1 /* NAM */ = {
+			isa = PBXGroup;
+			children = (
+				AAB1D0DF29E1026700EAAFE1 /* activations.h */,
+				AAB1D0E729E1026700EAAFE1 /* convnet.cpp */,
+				AAB1D0E029E1026700EAAFE1 /* convnet.h */,
+				AAB1D0E829E1026700EAAFE1 /* dsp.cpp */,
+				AAB1D0E929E1026800EAAFE1 /* dsp.h */,
+				AAB1D0E129E1026700EAAFE1 /* get_dsp.cpp */,
+				AAB1D0E529E1026700EAAFE1 /* lstm.cpp */,
+				AAB1D0E329E1026700EAAFE1 /* lstm.h */,
+				AAB1D0DE29E1026700EAAFE1 /* util.cpp */,
+				AAB1D0E429E1026700EAAFE1 /* util.h */,
+				AAB1D0EA29E1026800EAAFE1 /* version.h */,
+				AAB1D0E229E1026700EAAFE1 /* wavenet.cpp */,
+				AAB1D0E629E1026700EAAFE1 /* wavenet.h */,
+			);
+			path = NAM;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -773,22 +781,22 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA63408E29C54D4D00550809 /* cnpy.h in Headers */,
+				AAB1D0FA29E1026800EAAFE1 /* lstm.h in Headers */,
 				AA63407F29C54D4D00550809 /* wav.h in Headers */,
-				AA63407E29C54D4D00550809 /* util.h in Headers */,
-				AA63406529C54D4D00550809 /* lstm.h in Headers */,
 				AA63406029C54D4D00550809 /* Resample.h in Headers */,
+				AAB1D0EB29E1026800EAAFE1 /* activations.h in Headers */,
 				4FC6983C293BA5090076EC33 /* IPlugAUViewController.h in Headers */,
 				AA63406629C54D4D00550809 /* RecursiveLinearFilter.h in Headers */,
-				AA63406829C54D4D00550809 /* activations.h in Headers */,
+				AAB1D0EF29E1026800EAAFE1 /* convnet.h in Headers */,
+				AAB1D0F329E1026800EAAFE1 /* dsp.h in Headers */,
 				AA63406429C54D4D00550809 /* dsp.h in Headers */,
+				AAB1D10329E1026800EAAFE1 /* wavenet.h in Headers */,
 				AA63408A29C54D4D00550809 /* ImpulseResponse.h in Headers */,
-				AA63406729C54D4D00550809 /* numpy_util.h in Headers */,
-				AA63408029C54D4D00550809 /* version.h in Headers */,
+				AAB1D0FF29E1026800EAAFE1 /* version.h in Headers */,
 				4FC6983A293BA4F10076EC33 /* NeuralAmpModelerAU.h in Headers */,
 				4FC6983B293BA5020076EC33 /* IPlugAUAudioUnit.h in Headers */,
+				AAB1D0FE29E1026800EAAFE1 /* util.h in Headers */,
 				AA63407429C54D4D00550809 /* NoiseGate.h in Headers */,
-				AA63406F29C54D4D00550809 /* wavenet.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -983,37 +991,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAB1D0F229E1026800EAAFE1 /* dsp.cpp in Sources */,
 				4FE0DEF029A2E0F100DDBCC8 /* IPlugAUViewController.mm in Sources */,
+				AAB1D0F929E1026800EAAFE1 /* lstm.cpp in Sources */,
 				4FC6983D293BA5C40076EC33 /* IPlugAUAudioUnit.mm in Sources */,
 				AA63406329C54D4D00550809 /* RecursiveLinearFilter.cpp in Sources */,
-				AA63407A29C54D4D00550809 /* util.cpp in Sources */,
 				4FC6983E293BA5C40076EC33 /* IPlugAUv3.mm in Sources */,
 				4FC6984D293BA6140076EC33 /* IGraphicsNanoVG_src.m in Sources */,
+				AAB1D0EE29E1026800EAAFE1 /* convnet.cpp in Sources */,
 				4FC6984B293BA6010076EC33 /* IGraphicsIOS_view.mm in Sources */,
 				AA63407D29C54D4D00550809 /* NoiseGate.cpp in Sources */,
 				4FC69851293BA8770076EC33 /* IGraphicsIOS.mm in Sources */,
 				4FC69849293BA5F90076EC33 /* ITextEntryControl.cpp in Sources */,
 				4FC6984C293BA6010076EC33 /* IGraphicsCoreText.mm in Sources */,
 				4FC6984F293BA6420076EC33 /* IControl.cpp in Sources */,
+				AAB1D10229E1026800EAAFE1 /* wavenet.cpp in Sources */,
 				4FC69848293BA5F90076EC33 /* IControls.cpp in Sources */,
 				4FC69840293BA5C40076EC33 /* IPlugPluginBase.cpp in Sources */,
 				4FC6984A293BA5F90076EC33 /* IGraphics.cpp in Sources */,
 				4FC69841293BA5C40076EC33 /* IPlugAPIBase.cpp in Sources */,
-				AA63408929C54D4D00550809 /* get_dsp.cpp in Sources */,
 				4FC69842293BA5C50076EC33 /* IPlugProcessor.cpp in Sources */,
-				AA63408329C54D4D00550809 /* cnpy.cpp in Sources */,
+				AAB1D0F629E1026800EAAFE1 /* get_dsp.cpp in Sources */,
 				4FC69846293BA5F90076EC33 /* IGraphicsEditorDelegate.cpp in Sources */,
 				4FC69843293BA5C50076EC33 /* IPlugParameter.cpp in Sources */,
 				4FC69844293BA5C50076EC33 /* IPlugTimer.cpp in Sources */,
+				AAB1D0FD29E1026800EAAFE1 /* util.cpp in Sources */,
 				AA63407229C54D4D00550809 /* wav.cpp in Sources */,
-				AA63406E29C54D4D00550809 /* numpy_util.cpp in Sources */,
 				AA63408D29C54D4D00550809 /* dsp.cpp in Sources */,
-				AA63407729C54D4D00550809 /* lstm.cpp in Sources */,
 				4FC69845293BA5C50076EC33 /* IPlugPaths.mm in Sources */,
 				AA63408629C54D4D00550809 /* ImpulseResponse.cpp in Sources */,
 				4FC69847293BA5F90076EC33 /* IPopupMenuControl.cpp in Sources */,
 				4FC6984E293BA61D0076EC33 /* NeuralAmpModeler.cpp in Sources */,
-				AA63406B29C54D4D00550809 /* wavenet.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1023,19 +1031,19 @@
 			files = (
 				AA63406129C54D4D00550809 /* RecursiveLinearFilter.cpp in Sources */,
 				AA63408429C54D4D00550809 /* ImpulseResponse.cpp in Sources */,
+				AAB1D0F429E1026800EAAFE1 /* get_dsp.cpp in Sources */,
 				4FDF6D7F2267CEBA0007B686 /* IPlugAUPlayer.mm in Sources */,
 				AA63408B29C54D4D00550809 /* dsp.cpp in Sources */,
-				AA63407529C54D4D00550809 /* lstm.cpp in Sources */,
-				AA63408729C54D4D00550809 /* get_dsp.cpp in Sources */,
-				AA63407829C54D4D00550809 /* util.cpp in Sources */,
-				AA63406929C54D4D00550809 /* wavenet.cpp in Sources */,
+				AAB1D0F729E1026800EAAFE1 /* lstm.cpp in Sources */,
 				4FDF6D7B2267CE540007B686 /* AppDelegate.m in Sources */,
-				AA63406C29C54D4D00550809 /* numpy_util.cpp in Sources */,
+				AAB1D0F029E1026800EAAFE1 /* dsp.cpp in Sources */,
 				4FDF6D772267CE540007B686 /* AppViewController.mm in Sources */,
+				AAB1D0FB29E1026800EAAFE1 /* util.cpp in Sources */,
 				AA63407029C54D4D00550809 /* wav.cpp in Sources */,
 				AA63407B29C54D4D00550809 /* NoiseGate.cpp in Sources */,
 				4FDF6D792267CE540007B686 /* main.m in Sources */,
-				AA63408129C54D4D00550809 /* cnpy.cpp in Sources */,
+				AAB1D0EC29E1026800EAAFE1 /* convnet.cpp in Sources */,
+				AAB1D10029E1026800EAAFE1 /* wavenet.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1043,19 +1051,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAB1D0F129E1026800EAAFE1 /* dsp.cpp in Sources */,
 				AA63407129C54D4D00550809 /* wav.cpp in Sources */,
+				AAB1D0ED29E1026800EAAFE1 /* convnet.cpp in Sources */,
+				AAB1D0F829E1026800EAAFE1 /* lstm.cpp in Sources */,
 				AA63408C29C54D4D00550809 /* dsp.cpp in Sources */,
-				AA63407629C54D4D00550809 /* lstm.cpp in Sources */,
-				AA63408829C54D4D00550809 /* get_dsp.cpp in Sources */,
 				AA63406229C54D4D00550809 /* RecursiveLinearFilter.cpp in Sources */,
-				AA63408229C54D4D00550809 /* cnpy.cpp in Sources */,
 				AA63407C29C54D4D00550809 /* NoiseGate.cpp in Sources */,
-				AA63406D29C54D4D00550809 /* numpy_util.cpp in Sources */,
+				AAB1D0F529E1026800EAAFE1 /* get_dsp.cpp in Sources */,
 				4FCBE769293CDFB7005D913D /* IPlugAUViewController.mm in Sources */,
-				AA63406A29C54D4D00550809 /* wavenet.cpp in Sources */,
 				AA63408529C54D4D00550809 /* ImpulseResponse.cpp in Sources */,
 				4F4856842773BD77005BCF8E /* NeuralAmpModelerAUv3Appex.m in Sources */,
-				AA63407929C54D4D00550809 /* util.cpp in Sources */,
+				AAB1D0FC29E1026800EAAFE1 /* util.cpp in Sources */,
+				AAB1D10129E1026800EAAFE1 /* wavenet.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
@@ -331,18 +331,6 @@
 		AA633FC429C54D2000550809 /* ImpulseResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA429C54D1D00550809 /* ImpulseResponse.cpp */; };
 		AA633FC529C54D2000550809 /* ImpulseResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA429C54D1D00550809 /* ImpulseResponse.cpp */; };
 		AA633FC629C54D2000550809 /* ImpulseResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA429C54D1D00550809 /* ImpulseResponse.cpp */; };
-		AA633FC729C54D2000550809 /* cnpy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FA529C54D1D00550809 /* cnpy.h */; };
-		AA633FC829C54D2000550809 /* cnpy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FA529C54D1D00550809 /* cnpy.h */; };
-		AA633FC929C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FCA29C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FCB29C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FCC29C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FCD29C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FCE29C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FCF29C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FD029C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FD129C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
-		AA633FD229C54D2000550809 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA629C54D1E00550809 /* lstm.cpp */; };
 		AA633FD329C54D2000550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA729C54D1E00550809 /* wav.cpp */; };
 		AA633FD429C54D2000550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA729C54D1E00550809 /* wav.cpp */; };
 		AA633FD529C54D2000550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA729C54D1E00550809 /* wav.cpp */; };
@@ -353,54 +341,12 @@
 		AA633FDA29C54D2000550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA729C54D1E00550809 /* wav.cpp */; };
 		AA633FDB29C54D2000550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA729C54D1E00550809 /* wav.cpp */; };
 		AA633FDC29C54D2000550809 /* wav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA729C54D1E00550809 /* wav.cpp */; };
-		AA633FDD29C54D2000550809 /* activations.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FA829C54D1E00550809 /* activations.h */; };
-		AA633FDE29C54D2000550809 /* activations.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FA829C54D1E00550809 /* activations.h */; };
-		AA633FDF29C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE029C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE129C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE229C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE329C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE429C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE529C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE629C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE729C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
-		AA633FE829C54D2000550809 /* numpy_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FA929C54D1E00550809 /* numpy_util.cpp */; };
 		AA633FE929C54D2000550809 /* RecursiveLinearFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAA29C54D1E00550809 /* RecursiveLinearFilter.h */; };
 		AA633FEA29C54D2000550809 /* RecursiveLinearFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAA29C54D1E00550809 /* RecursiveLinearFilter.h */; };
-		AA633FEB29C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FEC29C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FED29C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FEE29C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FEF29C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FF029C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FF129C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FF229C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FF329C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FF429C54D2000550809 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FAB29C54D1E00550809 /* wavenet.cpp */; };
-		AA633FF729C54D2000550809 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAD29C54D1F00550809 /* version.h */; };
-		AA633FF829C54D2000550809 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAD29C54D1F00550809 /* version.h */; };
-		AA633FF929C54D2000550809 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAE29C54D1F00550809 /* wavenet.h */; };
-		AA633FFA29C54D2000550809 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAE29C54D1F00550809 /* wavenet.h */; };
-		AA633FFB29C54D2000550809 /* numpy_util.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAF29C54D1F00550809 /* numpy_util.h */; };
-		AA633FFC29C54D2000550809 /* numpy_util.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FAF29C54D1F00550809 /* numpy_util.h */; };
 		AA633FFD29C54D2000550809 /* NoiseGate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB029C54D1F00550809 /* NoiseGate.h */; };
 		AA633FFE29C54D2000550809 /* NoiseGate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB029C54D1F00550809 /* NoiseGate.h */; };
-		AA633FFF29C54D2000550809 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB129C54D1F00550809 /* util.h */; };
-		AA63400029C54D2000550809 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB129C54D1F00550809 /* util.h */; };
-		AA63400129C54D2100550809 /* lstm.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB229C54D1F00550809 /* lstm.h */; };
-		AA63400229C54D2100550809 /* lstm.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB229C54D1F00550809 /* lstm.h */; };
 		AA63400329C54D2100550809 /* Resample.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB329C54D1F00550809 /* Resample.h */; };
 		AA63400429C54D2100550809 /* Resample.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB329C54D1F00550809 /* Resample.h */; };
-		AA63400529C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400629C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400729C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400829C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400929C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400A29C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400B29C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400C29C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400D29C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
-		AA63400E29C54D2100550809 /* cnpy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB429C54D1F00550809 /* cnpy.cpp */; };
 		AA63400F29C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB529C54D1F00550809 /* RecursiveLinearFilter.cpp */; };
 		AA63401029C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB529C54D1F00550809 /* RecursiveLinearFilter.cpp */; };
 		AA63401129C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB529C54D1F00550809 /* RecursiveLinearFilter.cpp */; };
@@ -431,32 +377,86 @@
 		AA63402A29C54D2100550809 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB729C54D2000550809 /* dsp.cpp */; };
 		AA63402B29C54D2100550809 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB729C54D2000550809 /* dsp.cpp */; };
 		AA63402C29C54D2100550809 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB729C54D2000550809 /* dsp.cpp */; };
-		AA63402D29C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63402E29C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63402F29C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403029C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403129C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403229C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403329C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403429C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403529C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
-		AA63403629C54D2100550809 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FB829C54D2000550809 /* util.cpp */; };
 		AA63403729C54D2100550809 /* ImpulseResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB929C54D2000550809 /* ImpulseResponse.h */; };
 		AA63403829C54D2100550809 /* ImpulseResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FB929C54D2000550809 /* ImpulseResponse.h */; };
 		AA63403929C54D2100550809 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FBA29C54D2000550809 /* dsp.h */; };
 		AA63403A29C54D2100550809 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FBA29C54D2000550809 /* dsp.h */; };
-		AA63403B29C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63403C29C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63403D29C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63403E29C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63403F29C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63404029C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63404129C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63404229C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63404329C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
-		AA63404429C54D2100550809 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA633FBB29C54D2000550809 /* get_dsp.cpp */; };
 		AA63404529C54D2100550809 /* wav.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FBC29C54D2000550809 /* wav.h */; };
 		AA63404629C54D2100550809 /* wav.h in Headers */ = {isa = PBXBuildFile; fileRef = AA633FBC29C54D2000550809 /* wav.h */; };
+		AAB1D09329E1025600EAAFE1 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08629E1025500EAAFE1 /* version.h */; };
+		AAB1D09429E1025600EAAFE1 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08629E1025500EAAFE1 /* version.h */; };
+		AAB1D09529E1025600EAAFE1 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08729E1025500EAAFE1 /* util.h */; };
+		AAB1D09629E1025600EAAFE1 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08729E1025500EAAFE1 /* util.h */; };
+		AAB1D09729E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09829E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09929E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09A29E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09B29E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09C29E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09D29E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09E29E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D09F29E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D0A029E1025600EAAFE1 /* dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08829E1025500EAAFE1 /* dsp.cpp */; };
+		AAB1D0A129E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A229E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A329E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A429E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A529E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A629E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A729E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A829E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0A929E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0AA29E1025600EAAFE1 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08929E1025600EAAFE1 /* convnet.cpp */; };
+		AAB1D0AB29E1025600EAAFE1 /* convnet.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08A29E1025600EAAFE1 /* convnet.h */; };
+		AAB1D0AC29E1025600EAAFE1 /* convnet.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08A29E1025600EAAFE1 /* convnet.h */; };
+		AAB1D0AD29E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0AE29E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0AF29E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B029E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B129E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B229E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B329E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B429E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B529E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B629E1025600EAAFE1 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08B29E1025600EAAFE1 /* util.cpp */; };
+		AAB1D0B729E1025600EAAFE1 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08C29E1025600EAAFE1 /* wavenet.h */; };
+		AAB1D0B829E1025600EAAFE1 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08C29E1025600EAAFE1 /* wavenet.h */; };
+		AAB1D0B929E1025600EAAFE1 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08D29E1025600EAAFE1 /* dsp.h */; };
+		AAB1D0BA29E1025600EAAFE1 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D08D29E1025600EAAFE1 /* dsp.h */; };
+		AAB1D0BB29E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0BC29E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0BD29E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0BE29E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0BF29E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0C029E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0C129E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0C229E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0C329E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0C429E1025600EAAFE1 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */; };
+		AAB1D0C529E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0C629E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0C729E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0C829E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0C929E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0CA29E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0CB29E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0CC29E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0CD29E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0CE29E1025600EAAFE1 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */; };
+		AAB1D0CF29E1025600EAAFE1 /* lstm.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D09029E1025600EAAFE1 /* lstm.h */; };
+		AAB1D0D029E1025600EAAFE1 /* lstm.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D09029E1025600EAAFE1 /* lstm.h */; };
+		AAB1D0D129E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D229E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D329E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D429E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D529E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D629E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D729E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D829E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0D929E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0DA29E1025600EAAFE1 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAB1D09129E1025600EAAFE1 /* lstm.cpp */; };
+		AAB1D0DB29E1025600EAAFE1 /* activations.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D09229E1025600EAAFE1 /* activations.h */; };
+		AAB1D0DC29E1025600EAAFE1 /* activations.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB1D09229E1025600EAAFE1 /* activations.h */; };
 		B885CBC52304AE7300D73128 /* IPlugProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F8F61A8202807B9003F2573 /* IPlugProcessor.cpp */; };
 		B8E22A0C220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */; };
 		B8E22A0D220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */; };
@@ -992,29 +992,29 @@
 		52FBBED30D0CF143001C8B8A /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; name = config.h; path = ../config.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		AA355E2C295B688F0061AA3D /* Colors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Colors.h; path = ../Colors.h; sourceTree = "<group>"; };
 		AA633FA429C54D1D00550809 /* ImpulseResponse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ImpulseResponse.cpp; path = ../NeuralAmpModelerCore/dsp/ImpulseResponse.cpp; sourceTree = "<group>"; };
-		AA633FA529C54D1D00550809 /* cnpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cnpy.h; path = ../NeuralAmpModelerCore/dsp/cnpy.h; sourceTree = "<group>"; };
-		AA633FA629C54D1E00550809 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lstm.cpp; path = ../NeuralAmpModelerCore/dsp/lstm.cpp; sourceTree = "<group>"; };
 		AA633FA729C54D1E00550809 /* wav.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wav.cpp; path = ../NeuralAmpModelerCore/dsp/wav.cpp; sourceTree = "<group>"; };
-		AA633FA829C54D1E00550809 /* activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = activations.h; path = ../NeuralAmpModelerCore/dsp/activations.h; sourceTree = "<group>"; };
-		AA633FA929C54D1E00550809 /* numpy_util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = numpy_util.cpp; path = ../NeuralAmpModelerCore/dsp/numpy_util.cpp; sourceTree = "<group>"; };
 		AA633FAA29C54D1E00550809 /* RecursiveLinearFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RecursiveLinearFilter.h; path = ../NeuralAmpModelerCore/dsp/RecursiveLinearFilter.h; sourceTree = "<group>"; };
-		AA633FAB29C54D1E00550809 /* wavenet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wavenet.cpp; path = ../NeuralAmpModelerCore/dsp/wavenet.cpp; sourceTree = "<group>"; };
-		AA633FAD29C54D1F00550809 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../NeuralAmpModelerCore/dsp/version.h; sourceTree = "<group>"; };
-		AA633FAE29C54D1F00550809 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wavenet.h; path = ../NeuralAmpModelerCore/dsp/wavenet.h; sourceTree = "<group>"; };
-		AA633FAF29C54D1F00550809 /* numpy_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = numpy_util.h; path = ../NeuralAmpModelerCore/dsp/numpy_util.h; sourceTree = "<group>"; };
 		AA633FB029C54D1F00550809 /* NoiseGate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NoiseGate.h; path = ../NeuralAmpModelerCore/dsp/NoiseGate.h; sourceTree = "<group>"; };
-		AA633FB129C54D1F00550809 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = util.h; path = ../NeuralAmpModelerCore/dsp/util.h; sourceTree = "<group>"; };
-		AA633FB229C54D1F00550809 /* lstm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lstm.h; path = ../NeuralAmpModelerCore/dsp/lstm.h; sourceTree = "<group>"; };
 		AA633FB329C54D1F00550809 /* Resample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Resample.h; path = ../NeuralAmpModelerCore/dsp/Resample.h; sourceTree = "<group>"; };
-		AA633FB429C54D1F00550809 /* cnpy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cnpy.cpp; path = ../NeuralAmpModelerCore/dsp/cnpy.cpp; sourceTree = "<group>"; };
 		AA633FB529C54D1F00550809 /* RecursiveLinearFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RecursiveLinearFilter.cpp; path = ../NeuralAmpModelerCore/dsp/RecursiveLinearFilter.cpp; sourceTree = "<group>"; };
 		AA633FB629C54D2000550809 /* NoiseGate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NoiseGate.cpp; path = ../NeuralAmpModelerCore/dsp/NoiseGate.cpp; sourceTree = "<group>"; };
 		AA633FB729C54D2000550809 /* dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dsp.cpp; path = ../NeuralAmpModelerCore/dsp/dsp.cpp; sourceTree = "<group>"; };
-		AA633FB829C54D2000550809 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = ../NeuralAmpModelerCore/dsp/util.cpp; sourceTree = "<group>"; };
 		AA633FB929C54D2000550809 /* ImpulseResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImpulseResponse.h; path = ../NeuralAmpModelerCore/dsp/ImpulseResponse.h; sourceTree = "<group>"; };
 		AA633FBA29C54D2000550809 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dsp.h; path = ../NeuralAmpModelerCore/dsp/dsp.h; sourceTree = "<group>"; };
-		AA633FBB29C54D2000550809 /* get_dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = get_dsp.cpp; path = ../NeuralAmpModelerCore/dsp/get_dsp.cpp; sourceTree = "<group>"; };
 		AA633FBC29C54D2000550809 /* wav.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wav.h; path = ../NeuralAmpModelerCore/dsp/wav.h; sourceTree = "<group>"; };
+		AAB1D08629E1025500EAAFE1 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../../NeuralAmpModelerCore/NAM/version.h; sourceTree = "<group>"; };
+		AAB1D08729E1025500EAAFE1 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = util.h; path = ../../NeuralAmpModelerCore/NAM/util.h; sourceTree = "<group>"; };
+		AAB1D08829E1025500EAAFE1 /* dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dsp.cpp; path = ../../NeuralAmpModelerCore/NAM/dsp.cpp; sourceTree = "<group>"; };
+		AAB1D08929E1025600EAAFE1 /* convnet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convnet.cpp; path = ../../NeuralAmpModelerCore/NAM/convnet.cpp; sourceTree = "<group>"; };
+		AAB1D08A29E1025600EAAFE1 /* convnet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = convnet.h; path = ../../NeuralAmpModelerCore/NAM/convnet.h; sourceTree = "<group>"; };
+		AAB1D08B29E1025600EAAFE1 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = ../../NeuralAmpModelerCore/NAM/util.cpp; sourceTree = "<group>"; };
+		AAB1D08C29E1025600EAAFE1 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wavenet.h; path = ../../NeuralAmpModelerCore/NAM/wavenet.h; sourceTree = "<group>"; };
+		AAB1D08D29E1025600EAAFE1 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dsp.h; path = ../../NeuralAmpModelerCore/NAM/dsp.h; sourceTree = "<group>"; };
+		AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wavenet.cpp; path = ../../NeuralAmpModelerCore/NAM/wavenet.cpp; sourceTree = "<group>"; };
+		AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = get_dsp.cpp; path = ../../NeuralAmpModelerCore/NAM/get_dsp.cpp; sourceTree = "<group>"; };
+		AAB1D09029E1025600EAAFE1 /* lstm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lstm.h; path = ../../NeuralAmpModelerCore/NAM/lstm.h; sourceTree = "<group>"; };
+		AAB1D09129E1025600EAAFE1 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lstm.cpp; path = ../../NeuralAmpModelerCore/NAM/lstm.cpp; sourceTree = "<group>"; };
+		AAB1D09229E1025600EAAFE1 /* activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = activations.h; path = ../../NeuralAmpModelerCore/NAM/activations.h; sourceTree = "<group>"; };
 		AAD2484E29542F2800F55DD4 /* APPRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = APPRelease.entitlements; sourceTree = "<group>"; };
 		AAD2484F2954325200F55DD4 /* AUv3Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AUv3Release.entitlements; sourceTree = "<group>"; };
 		AAD248502954339400F55DD4 /* AUv3AppRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AUv3AppRelease.entitlements; sourceTree = "<group>"; };
@@ -1096,6 +1096,7 @@
 		089C166AFE841209C02AAC07 /* IPlugExample */ = {
 			isa = PBXGroup;
 			children = (
+				AAB1D08529E1023800EAAFE1 /* NAM */,
 				AA355E2C295B688F0061AA3D /* Colors.h */,
 				AAD248502954339400F55DD4 /* AUv3AppRelease.entitlements */,
 				AAD2484F2954325200F55DD4 /* AUv3Release.entitlements */,
@@ -1301,30 +1302,17 @@
 		4F3EF8AA28DE03ED002972F2 /* dsp */ = {
 			isa = PBXGroup;
 			children = (
-				AA633FA829C54D1E00550809 /* activations.h */,
-				AA633FB429C54D1F00550809 /* cnpy.cpp */,
-				AA633FA529C54D1D00550809 /* cnpy.h */,
 				AA633FB729C54D2000550809 /* dsp.cpp */,
 				AA633FBA29C54D2000550809 /* dsp.h */,
-				AA633FBB29C54D2000550809 /* get_dsp.cpp */,
 				AA633FA429C54D1D00550809 /* ImpulseResponse.cpp */,
 				AA633FB929C54D2000550809 /* ImpulseResponse.h */,
-				AA633FA629C54D1E00550809 /* lstm.cpp */,
-				AA633FB229C54D1F00550809 /* lstm.h */,
 				AA633FB629C54D2000550809 /* NoiseGate.cpp */,
 				AA633FB029C54D1F00550809 /* NoiseGate.h */,
-				AA633FA929C54D1E00550809 /* numpy_util.cpp */,
-				AA633FAF29C54D1F00550809 /* numpy_util.h */,
 				AA633FB529C54D1F00550809 /* RecursiveLinearFilter.cpp */,
 				AA633FAA29C54D1E00550809 /* RecursiveLinearFilter.h */,
 				AA633FB329C54D1F00550809 /* Resample.h */,
-				AA633FB829C54D2000550809 /* util.cpp */,
-				AA633FB129C54D1F00550809 /* util.h */,
-				AA633FAD29C54D1F00550809 /* version.h */,
 				AA633FA729C54D1E00550809 /* wav.cpp */,
 				AA633FBC29C54D2000550809 /* wav.h */,
-				AA633FAB29C54D1E00550809 /* wavenet.cpp */,
-				AA633FAE29C54D1F00550809 /* wavenet.h */,
 			);
 			name = dsp;
 			path = ../dsp;
@@ -1946,6 +1934,26 @@
 			name = WDL;
 			sourceTree = "<group>";
 		};
+		AAB1D08529E1023800EAAFE1 /* NAM */ = {
+			isa = PBXGroup;
+			children = (
+				AAB1D09229E1025600EAAFE1 /* activations.h */,
+				AAB1D08929E1025600EAAFE1 /* convnet.cpp */,
+				AAB1D08A29E1025600EAAFE1 /* convnet.h */,
+				AAB1D08829E1025500EAAFE1 /* dsp.cpp */,
+				AAB1D08D29E1025600EAAFE1 /* dsp.h */,
+				AAB1D08F29E1025600EAAFE1 /* get_dsp.cpp */,
+				AAB1D09129E1025600EAAFE1 /* lstm.cpp */,
+				AAB1D09029E1025600EAAFE1 /* lstm.h */,
+				AAB1D08B29E1025600EAAFE1 /* util.cpp */,
+				AAB1D08729E1025500EAAFE1 /* util.h */,
+				AAB1D08629E1025500EAAFE1 /* version.h */,
+				AAB1D08E29E1025600EAAFE1 /* wavenet.cpp */,
+				AAB1D08C29E1025600EAAFE1 /* wavenet.h */,
+			);
+			path = NAM;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1954,21 +1962,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA63400429C54D2100550809 /* Resample.h in Headers */,
-				AA63400229C54D2100550809 /* lstm.h in Headers */,
 				4F4856862773C3B5005BCF8E /* IPlugAUAudioUnit.h in Headers */,
-				AA633FFC29C54D2000550809 /* numpy_util.h in Headers */,
 				4F78BE1222E73DD900AD537E /* NeuralAmpModelerAU.h in Headers */,
 				AA63404629C54D2100550809 /* wav.h in Headers */,
-				AA633FF829C54D2000550809 /* version.h in Headers */,
 				4F4856852773C3B5005BCF8E /* IPlugAUViewController.h in Headers */,
+				AAB1D0B829E1025600EAAFE1 /* wavenet.h in Headers */,
 				AA633FEA29C54D2000550809 /* RecursiveLinearFilter.h in Headers */,
-				AA633FFA29C54D2000550809 /* wavenet.h in Headers */,
+				AAB1D0AC29E1025600EAAFE1 /* convnet.h in Headers */,
+				AAB1D09629E1025600EAAFE1 /* util.h in Headers */,
+				AAB1D09429E1025600EAAFE1 /* version.h in Headers */,
 				AA633FFE29C54D2000550809 /* NoiseGate.h in Headers */,
-				AA633FC829C54D2000550809 /* cnpy.h in Headers */,
 				AA355E2E295B688F0061AA3D /* Colors.h in Headers */,
-				AA63400029C54D2000550809 /* util.h in Headers */,
+				AAB1D0D029E1025600EAAFE1 /* lstm.h in Headers */,
+				AAB1D0BA29E1025600EAAFE1 /* dsp.h in Headers */,
 				AA63403829C54D2100550809 /* ImpulseResponse.h in Headers */,
-				AA633FDE29C54D2000550809 /* activations.h in Headers */,
+				AAB1D0DC29E1025600EAAFE1 /* activations.h in Headers */,
 				AA63403A29C54D2100550809 /* dsp.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1977,41 +1985,41 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA633FC729C54D2000550809 /* cnpy.h in Headers */,
 				AA355E2D295B688F0061AA3D /* Colors.h in Headers */,
-				AA633FFF29C54D2000550809 /* util.h in Headers */,
 				4FC3EFF02086CE5700BD11FA /* eventlist.h in Headers */,
 				4FC3EFF42086CE5700BD11FA /* module.h in Headers */,
 				4F03A58C20A4621100EBDFFB /* IGraphicsNanoVG.h in Headers */,
+				AAB1D09329E1025600EAAFE1 /* version.h in Headers */,
 				AA633FE929C54D2000550809 /* RecursiveLinearFilter.h in Headers */,
 				4F03A5D320A4621100EBDFFB /* IGraphicsStructs.h in Headers */,
 				4FC3EFF82086CE5700BD11FA /* optional.h in Headers */,
 				AA633FFD29C54D2000550809 /* NoiseGate.h in Headers */,
+				AAB1D0DB29E1025600EAAFE1 /* activations.h in Headers */,
 				4FC3F0012086CE5700BD11FA /* uid.h in Headers */,
 				4F03A5B620A4621100EBDFFB /* IGraphics_select.h in Headers */,
 				4F03A5AB20A4621100EBDFFB /* IGraphics_include_in_plug_hdr.h in Headers */,
 				AA63403729C54D2100550809 /* ImpulseResponse.h in Headers */,
 				4FC3EFF22086CE5700BD11FA /* hostclasses.h in Headers */,
 				AA63403929C54D2100550809 /* dsp.h in Headers */,
+				AAB1D0B729E1025600EAAFE1 /* wavenet.h in Headers */,
 				AA63400329C54D2100550809 /* Resample.h in Headers */,
-				AA633FFB29C54D2000550809 /* numpy_util.h in Headers */,
 				AA63404529C54D2100550809 /* wav.h in Headers */,
 				4F03A5D420A4621100EBDFFB /* IGraphicsUtilities.h in Headers */,
-				AA633FDD29C54D2000550809 /* activations.h in Headers */,
 				4F03A5AA20A4621100EBDFFB /* IGraphicsLiveEdit.h in Headers */,
-				AA633FF929C54D2000550809 /* wavenet.h in Headers */,
+				AAB1D0CF29E1025600EAAFE1 /* lstm.h in Headers */,
 				4F6369EA20A466470022C370 /* IControl.h in Headers */,
 				4F03A5D520A4621100EBDFFB /* IGraphicsConstants.h in Headers */,
-				AA633FF729C54D2000550809 /* version.h in Headers */,
-				AA63400129C54D2100550809 /* lstm.h in Headers */,
 				4FF3205820B2BFAB00269268 /* IPlugPaths.h in Headers */,
 				4F03A5B720A4621100EBDFFB /* IGraphics.h in Headers */,
 				4F6FD2B022675B6300FC59E6 /* IGraphicsCoreText.h in Headers */,
 				4F03A5D220A4621100EBDFFB /* IGraphicsPopupMenu.h in Headers */,
 				4FC3EFFE2086CE5700BD11FA /* processdata.h in Headers */,
+				AAB1D09529E1025600EAAFE1 /* util.h in Headers */,
+				AAB1D0AB29E1025600EAAFE1 /* convnet.h in Headers */,
 				4FC3F0002086CE5700BD11FA /* stringconvert.h in Headers */,
 				4F8C10E720BA2796006320CD /* IGraphicsEditorDelegate.h in Headers */,
 				4FC3EFFA2086CE5700BD11FA /* parameterchanges.h in Headers */,
+				AAB1D0B929E1025600EAAFE1 /* dsp.h in Headers */,
 				4F03A5B320A4621100EBDFFB /* IGraphics_include_in_plug_src.h in Headers */,
 				4FC3EFFC2086CE5700BD11FA /* plugprovider.h in Headers */,
 			);
@@ -2564,30 +2572,30 @@
 			files = (
 				4FDAC0EB207D76C600299363 /* IPlugTimer.cpp in Sources */,
 				4F03A5AD20A4621100EBDFFB /* IGraphics.cpp in Sources */,
-				AA633FEC29C54D2000550809 /* wavenet.cpp in Sources */,
+				AAB1D0D229E1025600EAAFE1 /* lstm.cpp in Sources */,
 				AA633FD429C54D2000550809 /* wav.cpp in Sources */,
 				4F5F344220C0226200487201 /* IPlugPaths.mm in Sources */,
-				AA633FE029C54D2000550809 /* numpy_util.cpp in Sources */,
+				AAB1D0A229E1025600EAAFE1 /* convnet.cpp in Sources */,
+				AAB1D0BC29E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F6369EC20A466470022C370 /* IControl.cpp in Sources */,
 				4FB1F58A20E4B005004157C8 /* IGraphicsMac.mm in Sources */,
 				4F1A527B205D910000CF2908 /* IPlugVST2.cpp in Sources */,
 				4F8C10E120BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
+				AAB1D0AE29E1025600EAAFE1 /* util.cpp in Sources */,
 				4F6369DE20A464BB0022C370 /* IGraphicsNanoVG_src.m in Sources */,
 				4F7C4958255DDFC400DF7588 /* IControls.cpp in Sources */,
 				4F8D9707209EF5AC006E2A11 /* NeuralAmpModeler.cpp in Sources */,
 				4F7C495A255DDFC400DF7588 /* ITextEntryControl.cpp in Sources */,
 				4F78D9BB13B63BA50032E0F3 /* IPlugAPIBase.cpp in Sources */,
-				AA63400629C54D2100550809 /* cnpy.cpp in Sources */,
 				4FB1F59020E4B010004157C8 /* IGraphicsMac_view.mm in Sources */,
-				AA63403C29C54D2100550809 /* get_dsp.cpp in Sources */,
 				AA63401029C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
+				AAB1D0C629E1025600EAAFE1 /* get_dsp.cpp in Sources */,
+				AAB1D09829E1025600EAAFE1 /* dsp.cpp in Sources */,
 				AA63402429C54D2100550809 /* dsp.cpp in Sources */,
 				AA633FBE29C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4F993F7223055C96000313AF /* IPlugProcessor.cpp in Sources */,
 				4F35DEAE207E5C5A00867D8F /* IPlugPluginBase.cpp in Sources */,
 				AA63401A29C54D2100550809 /* NoiseGate.cpp in Sources */,
-				AA633FCA29C54D2000550809 /* lstm.cpp in Sources */,
-				AA63402E29C54D2100550809 /* util.cpp in Sources */,
 				4F6FD2B222675B6300FC59E6 /* IGraphicsCoreText.mm in Sources */,
 				4F78D9C813B63BA50032E0F3 /* IPlugParameter.cpp in Sources */,
 				4F7C4959255DDFC400DF7588 /* IPopupMenuControl.cpp in Sources */,
@@ -2598,17 +2606,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAB1D0CB29E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				AA63401F29C54D2100550809 /* NoiseGate.cpp in Sources */,
-				AA633FCF29C54D2000550809 /* lstm.cpp in Sources */,
+				AAB1D0A729E1025600EAAFE1 /* convnet.cpp in Sources */,
+				AAB1D0B329E1025600EAAFE1 /* util.cpp in Sources */,
 				AA633FC329C54D2000550809 /* ImpulseResponse.cpp in Sources */,
-				AA633FF129C54D2000550809 /* wavenet.cpp in Sources */,
+				AAB1D0D729E1025600EAAFE1 /* lstm.cpp in Sources */,
+				AAB1D0C129E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F4856892773CA76005BCF8E /* NeuralAmpModelerAUv3Appex.m in Sources */,
-				AA633FE529C54D2000550809 /* numpy_util.cpp in Sources */,
 				AA63401529C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				AA63402929C54D2100550809 /* dsp.cpp in Sources */,
-				AA63400B29C54D2100550809 /* cnpy.cpp in Sources */,
-				AA63403329C54D2100550809 /* util.cpp in Sources */,
-				AA63404129C54D2100550809 /* get_dsp.cpp in Sources */,
+				AAB1D09D29E1025600EAAFE1 /* dsp.cpp in Sources */,
 				AA633FD929C54D2000550809 /* wav.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2618,33 +2626,33 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F7C495F255DDFC500DF7588 /* IPopupMenuControl.cpp in Sources */,
+				AAB1D09A29E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4F03A5AF20A4621100EBDFFB /* IGraphics.cpp in Sources */,
 				4F6369E020A464BB0022C370 /* IGraphicsNanoVG_src.m in Sources */,
 				4F6369EE20A466470022C370 /* IControl.cpp in Sources */,
 				4F1A528C205D916F00CF2908 /* IPlugAU.cpp in Sources */,
-				AA63400829C54D2100550809 /* cnpy.cpp in Sources */,
 				AA63401229C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4FD52131202A5B9B00A4D22A /* IPlugAU_view_factory.mm in Sources */,
 				4F993F7423055C96000313AF /* IPlugProcessor.cpp in Sources */,
+				AAB1D0A429E1025600EAAFE1 /* convnet.cpp in Sources */,
 				4F8C10E320BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
-				AA633FE229C54D2000550809 /* numpy_util.cpp in Sources */,
-				AA633FEE29C54D2000550809 /* wavenet.cpp in Sources */,
-				AA633FCC29C54D2000550809 /* lstm.cpp in Sources */,
 				4F6FD2B422675B6300FC59E6 /* IGraphicsCoreText.mm in Sources */,
 				AA63402629C54D2100550809 /* dsp.cpp in Sources */,
 				AA633FC029C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4FDAC0ED207D76C600299363 /* IPlugTimer.cpp in Sources */,
 				4F78D94513B63BA50032E0F3 /* IPlugAPIBase.cpp in Sources */,
+				AAB1D0BE29E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4FB1F59320E4B013004157C8 /* IGraphicsMac_view.mm in Sources */,
 				4FD52136202A5BD000A4D22A /* dfx-au-utilities.c in Sources */,
 				4F7C4960255DDFC500DF7588 /* ITextEntryControl.cpp in Sources */,
-				AA63403029C54D2100550809 /* util.cpp in Sources */,
-				AA63403E29C54D2100550809 /* get_dsp.cpp in Sources */,
 				4F5F344420C0226200487201 /* IPlugPaths.mm in Sources */,
 				4F7C495E255DDFC500DF7588 /* IControls.cpp in Sources */,
 				AA633FD629C54D2000550809 /* wav.cpp in Sources */,
 				AA63401C29C54D2100550809 /* NoiseGate.cpp in Sources */,
+				AAB1D0B029E1025600EAAFE1 /* util.cpp in Sources */,
 				4F35DEB0207E5C5A00867D8F /* IPlugPluginBase.cpp in Sources */,
+				AAB1D0C829E1025600EAAFE1 /* get_dsp.cpp in Sources */,
+				AAB1D0D429E1025600EAAFE1 /* lstm.cpp in Sources */,
 				4F78D95C13B63BA50032E0F3 /* IPlugParameter.cpp in Sources */,
 				4FB1F58C20E4B006004157C8 /* IGraphicsMac.mm in Sources */,
 				4F3862F22014BBEC0009F402 /* NeuralAmpModeler.cpp in Sources */,
@@ -2657,6 +2665,7 @@
 			files = (
 				4F3EE1C2231438D000004786 /* IPlugProcessor.cpp in Sources */,
 				4F3EE1C3231438D000004786 /* RtMidi.cpp in Sources */,
+				AAB1D0C429E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F3EE1C5231438D000004786 /* IGraphicsNanoVG_src.m in Sources */,
 				AA63401829C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4F3EE1C6231438D000004786 /* IControl.cpp in Sources */,
@@ -2669,24 +2678,22 @@
 				4F3EE1CD231438D000004786 /* swell-miscdlg.mm in Sources */,
 				4F7C496F255DDFCB00DF7588 /* ITextEntryControl.cpp in Sources */,
 				4F3EE1CF231438D000004786 /* swell-menu.mm in Sources */,
-				AA633FF429C54D2000550809 /* wavenet.cpp in Sources */,
-				AA63404429C54D2100550809 /* get_dsp.cpp in Sources */,
-				AA63400E29C54D2100550809 /* cnpy.cpp in Sources */,
 				4F3EE1D0231438D000004786 /* IGraphicsMac_view.mm in Sources */,
 				4F7C496E255DDFCB00DF7588 /* IPopupMenuControl.cpp in Sources */,
-				AA633FE829C54D2000550809 /* numpy_util.cpp in Sources */,
 				4F3EE1D1231438D000004786 /* swell-appstub.mm in Sources */,
 				4F7C496D255DDFCB00DF7588 /* IControls.cpp in Sources */,
 				4F3EE1D2231438D000004786 /* swell-misc.mm in Sources */,
 				AA633FC629C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4F3EE1D3231438D000004786 /* swell-wnd.mm in Sources */,
+				AAB1D0CE29E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				AA63402C29C54D2100550809 /* dsp.cpp in Sources */,
 				4F3EE1D4231438D000004786 /* swell.cpp in Sources */,
+				AAB1D0B629E1025600EAAFE1 /* util.cpp in Sources */,
+				AAB1D0A029E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4F3EE1D5231438D000004786 /* IPlugAPP_host.cpp in Sources */,
 				4F3EE1D6231438D000004786 /* IPlugAPP.cpp in Sources */,
 				4F3EE1D7231438D000004786 /* IGraphics.cpp in Sources */,
 				4F3EE1D8231438D000004786 /* IPlugAPP_dialog.cpp in Sources */,
-				AA633FD229C54D2000550809 /* lstm.cpp in Sources */,
 				4F3EE1D9231438D000004786 /* RtAudio.cpp in Sources */,
 				4F3EE1DA231438D000004786 /* IGraphicsCoreText.mm in Sources */,
 				4F3EE1DB231438D000004786 /* IPlugAPP_main.cpp in Sources */,
@@ -2694,11 +2701,12 @@
 				4F3EE1DE231438D000004786 /* NeuralAmpModeler.cpp in Sources */,
 				4F3EE1E0231438D000004786 /* IPlugAPIBase.cpp in Sources */,
 				4F3EE1E1231438D000004786 /* IPlugPluginBase.cpp in Sources */,
-				AA63403629C54D2100550809 /* util.cpp in Sources */,
+				AAB1D0DA29E1025600EAAFE1 /* lstm.cpp in Sources */,
 				4F3EE1E2231438D000004786 /* IGraphicsEditorDelegate.cpp in Sources */,
 				4F3EE1E3231438D000004786 /* swell-gdi.mm in Sources */,
 				AA63402229C54D2100550809 /* NoiseGate.cpp in Sources */,
 				4F3EE1E4231438D000004786 /* IPlugParameter.cpp in Sources */,
+				AAB1D0AA29E1025600EAAFE1 /* convnet.cpp in Sources */,
 				4F3EE1E5231438D000004786 /* IPlugTimer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2707,38 +2715,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAB1D09F29E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4F7C496A255DDFCB00DF7588 /* IControls.cpp in Sources */,
 				4F78BE1422E7406D00AD537E /* NeuralAmpModeler.h in Sources */,
 				AA63401729C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4F0D965C23099F6900BFDED0 /* IPlugProcessor.cpp in Sources */,
-				AA633FD129C54D2000550809 /* lstm.cpp in Sources */,
+				AAB1D0A929E1025600EAAFE1 /* convnet.cpp in Sources */,
 				4F78BE1522E7406D00AD537E /* NeuralAmpModeler.cpp in Sources */,
 				4F78BE1622E7406D00AD537E /* IGraphicsMac_view.mm in Sources */,
+				AAB1D0CD29E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				4F78BE1722E7406D00AD537E /* IGraphicsMac.mm in Sources */,
 				4F78BE1822E7406D00AD537E /* IGraphicsCoreText.mm in Sources */,
 				AA63402B29C54D2100550809 /* dsp.cpp in Sources */,
 				4F78BE1E22E7406D00AD537E /* IGraphicsNanoVG_src.m in Sources */,
-				AA63400D29C54D2100550809 /* cnpy.cpp in Sources */,
-				AA63404329C54D2100550809 /* get_dsp.cpp in Sources */,
 				4F78BE1F22E7406D00AD537E /* IGraphics.cpp in Sources */,
 				4F78BE2022E7406D00AD537E /* IGraphicsEditorDelegate.cpp in Sources */,
+				AAB1D0C329E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F78BE2122E7406D00AD537E /* IControl.cpp in Sources */,
 				4F78BE2222E7406D00AD537E /* IPlugAUAudioUnit.mm in Sources */,
+				AAB1D0B529E1025600EAAFE1 /* util.cpp in Sources */,
 				4F7C496C255DDFCB00DF7588 /* ITextEntryControl.cpp in Sources */,
 				AA63402129C54D2100550809 /* NoiseGate.cpp in Sources */,
-				AA63403529C54D2100550809 /* util.cpp in Sources */,
 				4F78BE2322E7406D00AD537E /* IPlugAUv3.mm in Sources */,
 				4F78BE2422E7406D00AD537E /* IPlugAUViewController.mm in Sources */,
 				4F78BE2522E7406D00AD537E /* IPlugPluginBase.cpp in Sources */,
 				4F78BE2622E7406D00AD537E /* IPlugAPIBase.cpp in Sources */,
+				AAB1D0D929E1025600EAAFE1 /* lstm.cpp in Sources */,
 				AA633FDB29C54D2000550809 /* wav.cpp in Sources */,
 				4F78BE2822E7406D00AD537E /* IPlugParameter.cpp in Sources */,
 				4F78BE2922E7406D00AD537E /* IPlugTimer.cpp in Sources */,
 				AA633FC529C54D2000550809 /* ImpulseResponse.cpp in Sources */,
-				AA633FE729C54D2000550809 /* numpy_util.cpp in Sources */,
 				4F78BE2A22E7406D00AD537E /* IPlugPaths.mm in Sources */,
 				4F7C496B255DDFCB00DF7588 /* IPopupMenuControl.cpp in Sources */,
-				AA633FF329C54D2000550809 /* wavenet.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2762,19 +2770,16 @@
 				4F9828C1140A9EB700F3FCC1 /* IPlugParameter.cpp in Sources */,
 				AA633FBF29C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4F81591A205D50EB00393585 /* pluginview.cpp in Sources */,
+				AAB1D0BD29E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F815982205D50EB00393585 /* fstring.cpp in Sources */,
 				4F815995205D51F000393585 /* vstpresetfile.cpp in Sources */,
 				AA63401B29C54D2100550809 /* NoiseGate.cpp in Sources */,
-				AA633FE129C54D2000550809 /* numpy_util.cpp in Sources */,
-				AA63402F29C54D2100550809 /* util.cpp in Sources */,
 				4F815983205D50EB00393585 /* timer.cpp in Sources */,
 				AA63402529C54D2100550809 /* dsp.cpp in Sources */,
 				4F815989205D50EB00393585 /* funknown.cpp in Sources */,
 				4FB1F58B20E4B006004157C8 /* IGraphicsMac.mm in Sources */,
 				4F81598E205D51F000393585 /* vstbus.cpp in Sources */,
-				AA63403D29C54D2100550809 /* get_dsp.cpp in Sources */,
 				4F6369ED20A466470022C370 /* IControl.cpp in Sources */,
-				AA633FCB29C54D2000550809 /* lstm.cpp in Sources */,
 				4F35DEAF207E5C5A00867D8F /* IPlugPluginBase.cpp in Sources */,
 				4F81591E205D50EB00393585 /* macmain.cpp in Sources */,
 				4F993F7323055C96000313AF /* IPlugProcessor.cpp in Sources */,
@@ -2782,30 +2787,33 @@
 				4F5F344320C0226200487201 /* IPlugPaths.mm in Sources */,
 				4F81598A205D50EB00393585 /* ustring.cpp in Sources */,
 				4F7C495C255DDFC400DF7588 /* IPopupMenuControl.cpp in Sources */,
+				AAB1D0AF29E1025600EAAFE1 /* util.cpp in Sources */,
 				4F815980205D50EB00393585 /* fobject.cpp in Sources */,
+				AAB1D0A329E1025600EAAFE1 /* convnet.cpp in Sources */,
 				AA63401129C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4F815994205D51F000393585 /* vstparameters.cpp in Sources */,
 				4F6369DF20A464BB0022C370 /* IGraphicsNanoVG_src.m in Sources */,
 				4F815991205D51F000393585 /* vstcomponentbase.cpp in Sources */,
 				4F03A5AE20A4621100EBDFFB /* IGraphics.cpp in Sources */,
+				AAB1D09929E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4F815987205D50EB00393585 /* conststringtable.cpp in Sources */,
 				4F722020225C1EB100FF0E7C /* commoniids.cpp in Sources */,
-				AA63400729C54D2100550809 /* cnpy.cpp in Sources */,
 				4FB1F59220E4B012004157C8 /* IGraphicsMac_view.mm in Sources */,
 				4F81598D205D51F000393585 /* vstaudioeffect.cpp in Sources */,
 				AA633FD529C54D2000550809 /* wav.cpp in Sources */,
+				AAB1D0C729E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				4F81598C205D51CF00393585 /* vstsinglecomponenteffect.cpp in Sources */,
 				4F815984205D50EB00393585 /* updatehandler.cpp in Sources */,
 				4F815990205D51F000393585 /* vstcomponent.cpp in Sources */,
 				4F815981205D50EB00393585 /* fstreamer.cpp in Sources */,
 				4F815996205D51F000393585 /* vstrepresentation.cpp in Sources */,
+				AAB1D0D329E1025600EAAFE1 /* lstm.cpp in Sources */,
 				4F815985205D50EB00393585 /* fcondition.cpp in Sources */,
 				4F8C10E220BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
 				4F81597D205D50EB00393585 /* fbuffer.cpp in Sources */,
 				4F1A527E205D911A00CF2908 /* IPlugVST3.cpp in Sources */,
 				4F815988205D50EB00393585 /* coreiids.cpp in Sources */,
 				4F815993205D51F000393585 /* vstnoteexpressiontypes.cpp in Sources */,
-				AA633FED29C54D2000550809 /* wavenet.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2813,38 +2821,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAB1D09B29E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4F7C4961255DDFC600DF7588 /* IControls.cpp in Sources */,
 				4F993F7523055C97000313AF /* IPlugProcessor.cpp in Sources */,
 				AA63401329C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4FDAC0EE207D76C600299363 /* IPlugTimer.cpp in Sources */,
-				AA633FCD29C54D2000550809 /* lstm.cpp in Sources */,
+				AAB1D0A529E1025600EAAFE1 /* convnet.cpp in Sources */,
 				4F8C10E420BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
 				4F6369E120A464BB0022C370 /* IGraphicsNanoVG_src.m in Sources */,
+				AAB1D0C929E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				4FB6001A1567CB0A0020189A /* IPlugAPIBase.cpp in Sources */,
 				4F6369EF20A466470022C370 /* IControl.cpp in Sources */,
 				AA63402729C54D2100550809 /* dsp.cpp in Sources */,
 				4F03A5B020A4621100EBDFFB /* IGraphics.cpp in Sources */,
-				AA63400929C54D2100550809 /* cnpy.cpp in Sources */,
-				AA63403F29C54D2100550809 /* get_dsp.cpp in Sources */,
 				4F35DEB1207E5C5A00867D8F /* IPlugPluginBase.cpp in Sources */,
 				4F5F344520C0226200487201 /* IPlugPaths.mm in Sources */,
+				AAB1D0BF29E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F1A5285205D914A00CF2908 /* IPlugAAX.cpp in Sources */,
 				4F0848292015129A00F9E881 /* IPlugAAX_Parameters.cpp in Sources */,
+				AAB1D0B129E1025600EAAFE1 /* util.cpp in Sources */,
 				4FB1F59420E4B014004157C8 /* IGraphicsMac_view.mm in Sources */,
 				AA63401D29C54D2100550809 /* NoiseGate.cpp in Sources */,
-				AA63403129C54D2100550809 /* util.cpp in Sources */,
 				4F7C4963255DDFC600DF7588 /* ITextEntryControl.cpp in Sources */,
 				4F3862F32014BBEC0009F402 /* NeuralAmpModeler.cpp in Sources */,
 				4FB600231567CB0A0020189A /* IPlugParameter.cpp in Sources */,
 				4FB600261567CB0A0020189A /* AAX_Exports.cpp in Sources */,
+				AAB1D0D529E1025600EAAFE1 /* lstm.cpp in Sources */,
 				AA633FD729C54D2000550809 /* wav.cpp in Sources */,
 				4F6FD2B522675B6300FC59E6 /* IGraphicsCoreText.mm in Sources */,
 				4FB600281567CB0A0020189A /* IPlugAAX_Describe.cpp in Sources */,
 				AA633FC129C54D2000550809 /* ImpulseResponse.cpp in Sources */,
-				AA633FE329C54D2000550809 /* numpy_util.cpp in Sources */,
 				4FB1F58D20E4B007004157C8 /* IGraphicsMac.mm in Sources */,
 				4F7C4962255DDFC600DF7588 /* IPopupMenuControl.cpp in Sources */,
-				AA633FEF29C54D2000550809 /* wavenet.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2856,26 +2864,26 @@
 				4F03A5B220A4621100EBDFFB /* IGraphics.cpp in Sources */,
 				AA63401629C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4F7C4966255DDFC800DF7588 /* ITextEntryControl.cpp in Sources */,
-				AA633FE629C54D2000550809 /* numpy_util.cpp in Sources */,
 				4FB1F58F20E4B009004157C8 /* IGraphicsMac.mm in Sources */,
+				AAB1D0D829E1025600EAAFE1 /* lstm.cpp in Sources */,
+				AAB1D0B429E1025600EAAFE1 /* util.cpp in Sources */,
 				4F6369F120A466470022C370 /* IControl.cpp in Sources */,
 				4F6FD2B722675B6300FC59E6 /* IGraphicsCoreText.mm in Sources */,
 				AA633FDA29C54D2000550809 /* wav.cpp in Sources */,
-				AA633FD029C54D2000550809 /* lstm.cpp in Sources */,
 				AA63402029C54D2100550809 /* NoiseGate.cpp in Sources */,
 				4F8C10E620BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
-				AA63400C29C54D2100550809 /* cnpy.cpp in Sources */,
-				AA63403429C54D2100550809 /* util.cpp in Sources */,
+				AAB1D0CC29E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				4FC3EFF92086CE5700BD11FA /* parameterchanges.cpp in Sources */,
-				AA633FF229C54D2000550809 /* wavenet.cpp in Sources */,
 				4FC3EFCE2086C35D00BD11FA /* IPlugPluginBase.cpp in Sources */,
+				AAB1D09E29E1025600EAAFE1 /* dsp.cpp in Sources */,
+				AAB1D0C229E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				AA63402A29C54D2100550809 /* dsp.cpp in Sources */,
 				4F7C4965255DDFC800DF7588 /* IPopupMenuControl.cpp in Sources */,
 				AA633FC429C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4F722021225C1EB100FF0E7C /* commoniids.cpp in Sources */,
 				4FB1F59620E4B017004157C8 /* IGraphicsMac_view.mm in Sources */,
-				AA63404229C54D2100550809 /* get_dsp.cpp in Sources */,
 				4F472103209B294400A0A0A8 /* IPlugVST3_Controller.cpp in Sources */,
+				AAB1D0A829E1025600EAAFE1 /* convnet.cpp in Sources */,
 				4F78BE2D22E7412300AD537E /* IGraphicsNanoVG_src.m in Sources */,
 				4FC3EFCB2086C27800BD11FA /* NeuralAmpModeler.cpp in Sources */,
 			);
@@ -2887,6 +2895,7 @@
 			files = (
 				B885CBC52304AE7300D73128 /* IPlugProcessor.cpp in Sources */,
 				4F10D3D9203A6719003EF82A /* RtMidi.cpp in Sources */,
+				AAB1D0BB29E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4F6369DD20A464BB0022C370 /* IGraphicsNanoVG_src.m in Sources */,
 				AA63400F29C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
 				4F6369EB20A466470022C370 /* IControl.cpp in Sources */,
@@ -2899,24 +2908,22 @@
 				4FD16D3C13B6358C001D0217 /* swell-miscdlg.mm in Sources */,
 				4F7C4957255DDFC300DF7588 /* ITextEntryControl.cpp in Sources */,
 				4FD16D3E13B63595001D0217 /* swell-menu.mm in Sources */,
-				AA633FEB29C54D2000550809 /* wavenet.cpp in Sources */,
-				AA63403B29C54D2100550809 /* get_dsp.cpp in Sources */,
-				AA63400529C54D2100550809 /* cnpy.cpp in Sources */,
 				4FB1F59120E4B011004157C8 /* IGraphicsMac_view.mm in Sources */,
 				4F7C4956255DDFC300DF7588 /* IPopupMenuControl.cpp in Sources */,
-				AA633FDF29C54D2000550809 /* numpy_util.cpp in Sources */,
 				4F5C5F6B21BED08700E024A7 /* swell-appstub.mm in Sources */,
 				4F7C4955255DDFC300DF7588 /* IControls.cpp in Sources */,
 				4FD16D4013B635A0001D0217 /* swell-misc.mm in Sources */,
 				AA633FBD29C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4FD16D4213B635AB001D0217 /* swell-wnd.mm in Sources */,
+				AAB1D0C529E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				AA63402329C54D2100550809 /* dsp.cpp in Sources */,
 				4FD16D4413B635B2001D0217 /* swell.cpp in Sources */,
+				AAB1D0AD29E1025600EAAFE1 /* util.cpp in Sources */,
+				AAB1D09729E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4F690CA3203A45C700A4A13E /* IPlugAPP_host.cpp in Sources */,
 				4F1A5282205D913300CF2908 /* IPlugAPP.cpp in Sources */,
 				4F03A5AC20A4621100EBDFFB /* IGraphics.cpp in Sources */,
 				4F2EA978203A50EA008E4850 /* IPlugAPP_dialog.cpp in Sources */,
-				AA633FC929C54D2000550809 /* lstm.cpp in Sources */,
 				4FAFFE5821495A4800A6E72D /* RtAudio.cpp in Sources */,
 				4F6FD2B122675B6300FC59E6 /* IGraphicsCoreText.mm in Sources */,
 				4F690C9B203A345100A4A13E /* IPlugAPP_main.cpp in Sources */,
@@ -2924,11 +2931,12 @@
 				4F3862EF2014BBEC0009F402 /* NeuralAmpModeler.cpp in Sources */,
 				4F78D90B13B63BA50032E0F3 /* IPlugAPIBase.cpp in Sources */,
 				4F35DEAD207E5C5A00867D8F /* IPlugPluginBase.cpp in Sources */,
-				AA63402D29C54D2100550809 /* util.cpp in Sources */,
+				AAB1D0D129E1025600EAAFE1 /* lstm.cpp in Sources */,
 				4F8C10E020BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
 				4FF0A83221BE708700B2C9D1 /* swell-gdi.mm in Sources */,
 				AA63401929C54D2100550809 /* NoiseGate.cpp in Sources */,
 				4F78D91813B63BA50032E0F3 /* IPlugParameter.cpp in Sources */,
+				AAB1D0A129E1025600EAAFE1 /* convnet.cpp in Sources */,
 				4FDAC0EA207D76C600299363 /* IPlugTimer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2939,19 +2947,20 @@
 			files = (
 				4FFBB90520863B0E00DDD0E7 /* baseiids.cpp in Sources */,
 				4FFBB90620863B0E00DDD0E7 /* IPlugTimer.cpp in Sources */,
+				AAB1D0CA29E1025600EAAFE1 /* get_dsp.cpp in Sources */,
 				4FFBB90720863B0E00DDD0E7 /* NeuralAmpModeler.cpp in Sources */,
-				AA63400A29C54D2100550809 /* cnpy.cpp in Sources */,
 				4FFBB90820863B0E00DDD0E7 /* pluginfactory.cpp in Sources */,
 				4FFBB90920863B0E00DDD0E7 /* vstinitiids.cpp in Sources */,
-				AA633FCE29C54D2000550809 /* lstm.cpp in Sources */,
+				AAB1D0B229E1025600EAAFE1 /* util.cpp in Sources */,
 				4FFBB90A20863B0E00DDD0E7 /* fdebug.cpp in Sources */,
 				AA63401E29C54D2100550809 /* NoiseGate.cpp in Sources */,
 				4FFBB90C20863B0E00DDD0E7 /* IPlugAPIBase.cpp in Sources */,
 				B8E22A0D220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */,
-				AA633FE429C54D2000550809 /* numpy_util.cpp in Sources */,
+				AAB1D0A629E1025600EAAFE1 /* convnet.cpp in Sources */,
 				AA633FD829C54D2000550809 /* wav.cpp in Sources */,
 				4FFBB90D20863B0E00DDD0E7 /* fdynlib.cpp in Sources */,
 				4FFBB90E20863B0E00DDD0E7 /* memorystream.cpp in Sources */,
+				AAB1D0D629E1025600EAAFE1 /* lstm.cpp in Sources */,
 				4FFBB90F20863B0E00DDD0E7 /* IPlugParameter.cpp in Sources */,
 				AA633FC229C54D2000550809 /* ImpulseResponse.cpp in Sources */,
 				4FFBB91020863B0E00DDD0E7 /* pluginview.cpp in Sources */,
@@ -2959,7 +2968,6 @@
 				4FFBB91320863B0E00DDD0E7 /* vstpresetfile.cpp in Sources */,
 				4FFBB91520863B0E00DDD0E7 /* timer.cpp in Sources */,
 				4FFBB91720863B0E00DDD0E7 /* funknown.cpp in Sources */,
-				AA63404029C54D2100550809 /* get_dsp.cpp in Sources */,
 				4FFBB91820863B0E00DDD0E7 /* vstbus.cpp in Sources */,
 				4FFBB91920863B0E00DDD0E7 /* IPlugPluginBase.cpp in Sources */,
 				AA63401429C54D2100550809 /* RecursiveLinearFilter.cpp in Sources */,
@@ -2968,10 +2976,9 @@
 				4FFBB91D20863B0E00DDD0E7 /* ustring.cpp in Sources */,
 				4FFBB91E20863B0E00DDD0E7 /* fobject.cpp in Sources */,
 				4FFBB91F20863B0E00DDD0E7 /* vstparameters.cpp in Sources */,
-				AA633FF029C54D2000550809 /* wavenet.cpp in Sources */,
+				AAB1D09C29E1025600EAAFE1 /* dsp.cpp in Sources */,
 				4FFBB92120863B0E00DDD0E7 /* vstcomponentbase.cpp in Sources */,
 				4FFBB92220863B0E00DDD0E7 /* IPlugVST3_Processor.cpp in Sources */,
-				AA63403229C54D2100550809 /* util.cpp in Sources */,
 				4F993F7623055C98000313AF /* IPlugProcessor.cpp in Sources */,
 				4FFBB92320863B0E00DDD0E7 /* conststringtable.cpp in Sources */,
 				4FFBB92420863B0E00DDD0E7 /* vstaudioeffect.cpp in Sources */,
@@ -2982,6 +2989,7 @@
 				4FFBB92D20863B0E00DDD0E7 /* vstrepresentation.cpp in Sources */,
 				4FFBB92E20863B0E00DDD0E7 /* fcondition.cpp in Sources */,
 				4FFBB93020863B0E00DDD0E7 /* fbuffer.cpp in Sources */,
+				AAB1D0C029E1025600EAAFE1 /* wavenet.cpp in Sources */,
 				4FFBB93420863B0E00DDD0E7 /* coreiids.cpp in Sources */,
 				AA63402829C54D2100550809 /* dsp.cpp in Sources */,
 				4F5F344720C0226200487201 /* IPlugPaths.mm in Sources */,
@@ -3858,6 +3866,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 0.5.7;
 				DEAD_CODE_STRIPPING = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 77BKRC84G3;
 				DSTROOT = "$(VST3_PATH)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(EXTRA_PLUGIN_DEFS)",

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
@@ -328,19 +328,19 @@
     <ClInclude Include="..\..\iPlug2\IPlug\VST3\IPlugVST3_View.h" />
     <ClInclude Include="..\Colors.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\activations.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\cnpy.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\dsp.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\lstm.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\NoiseGate.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\numpy_util.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\Resample.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\util.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\version.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\wav.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\wavenet.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\wavenet.h" />
     <ClInclude Include="..\resources\resource.h" />
   </ItemGroup>
   <ItemGroup>
@@ -403,17 +403,31 @@
     <ClCompile Include="..\..\iPlug2\IPlug\VST3\IPlugVST3.cpp" />
     <ClCompile Include="..\..\iPlug2\IPlug\VST3\IPlugVST3_ProcessorBase.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\cnpy.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\get_dsp.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\lstm.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\NoiseGate.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\numpy_util.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\util.cpp" />
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\wav.cpp" />
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\wavenet.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\convnet.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\dsp.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(RelativeDir)</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\get_dsp.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\lstm.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\util.cpp" />
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\wavenet.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\resources\main.rc" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj.filters
@@ -134,38 +134,38 @@
     <ClCompile Include="..\..\iPlug2\IGraphics\IGraphicsEditorDelegate.cpp">
       <Filter>IGraphics</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\cnpy.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\dsp.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\get_dsp.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\lstm.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\NoiseGate.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\numpy_util.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\util.cpp">
-      <Filter>dsp</Filter>
-    </ClCompile>
     <ClCompile Include="..\NeuralAmpModelerCore\dsp\wav.cpp">
       <Filter>dsp</Filter>
     </ClCompile>
-    <ClCompile Include="..\NeuralAmpModelerCore\dsp\wavenet.cpp">
-      <Filter>dsp</Filter>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\convnet.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\dsp.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\get_dsp.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\lstm.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\util.cpp">
+      <Filter>NAM</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NeuralAmpModelerCore\NAM\wavenet.cpp">
+      <Filter>NAM</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -391,25 +391,13 @@
       <Filter>IGraphics</Filter>
     </ClInclude>
     <ClInclude Include="..\Colors.h" />
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\activations.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\cnpy.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\dsp.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\ImpulseResponse.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\lstm.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\NoiseGate.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\numpy_util.h">
       <Filter>dsp</Filter>
     </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\RecursiveLinearFilter.h">
@@ -418,17 +406,29 @@
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\Resample.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\util.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\version.h">
-      <Filter>dsp</Filter>
-    </ClInclude>
     <ClInclude Include="..\NeuralAmpModelerCore\dsp\wav.h">
       <Filter>dsp</Filter>
     </ClInclude>
-    <ClInclude Include="..\NeuralAmpModelerCore\dsp\wavenet.h">
-      <Filter>dsp</Filter>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\wavenet.h">
+      <Filter>NAM</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -491,6 +491,9 @@
     </Filter>
     <Filter Include="dsp">
       <UniqueIdentifier>{982fc658-4802-43b8-95dd-f18fb814e389}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="NAM">
+      <UniqueIdentifier>{3d65ee8b-86ee-4713-a5ec-d73919c6419c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Resolves #153 

Models with version 0.5.1 and later contain a "loudness" metadatum that is used to tell how loud the output is, given a nominal test signal. This is used to calibrate the output loudness and ensures that models are the same loudness as you switch between them.

Disable to go back to the output that matches the training data as-recorded.

Uses an update to [NeuralAmpModelerCore](https://github.com/sdatkinson/NeuralAmpModelerCore)