### PR TITLE
Hide normalization toggle for model without loudness param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 xcuserdata
 *.RPP-bak
 build-*
+.idea/
 
 *.ipch
 *.db

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -349,7 +349,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     IVSlideSwitchControl* outputNormSlider = new IVSlideSwitchControl(outNormToggleArea, kOutNorm, "Normalize", style,
                                                                       true, // valueInButton
                                                                       EDirection::Horizontal);
-    pGraphics->AttachControl(outputNormSlider);
+    pGraphics->AttachControl(outputNormSlider, kOutNorm);
 
     // The knobs
     // Input
@@ -645,6 +645,8 @@ void NeuralAmpModeler::_ApplyDSPStaging()
     // Move from staged to active DSP
     this->mNAM = std::move(this->mStagedNAM);
     this->mStagedNAM = nullptr;
+    // Disable Normalization toggle when no loudness data in model metadata
+    GetUI()->GetControlWithTag(kOutNorm)->SetDisabled(!mNAM->HasLoudness());
   }
   if (this->mStagedIR != nullptr)
   {


### PR DESCRIPTION
This PR is to implement deactivation of Normalize toggle for models without loudness param. At each model loading logic will handle checking whether model is providing loudness param, and decide if normalisation toggle should be deactivated/activated. 

Expected results:

- Model without loudness data
<img width="604" alt="image" src="https://user-images.githubusercontent.com/59369050/232059048-55333ea1-33f2-4f11-b4db-5506d2aedf6e.png">

- Model with loudness data
<img width="604" alt="image" src="https://user-images.githubusercontent.com/59369050/232059148-536e8349-1d44-4be5-9360-6d5208c46626.png">

Fixes #183
