### PR TITLE
Fix loading models with special characters in the path

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -699,7 +699,7 @@ std::string NeuralAmpModeler::_GetNAM(const WDL_String& modelPath)
   WDL_String previousNAMPath = this->mNAMPath;
   try
   {
-    auto dspPath = std::filesystem::path(modelPath.Get());
+    auto dspPath = std::filesystem::u8path(modelPath.Get());
     mStagedNAM = get_dsp(dspPath);
     this->_SetModelMsg(modelPath);
     this->mNAMPath = modelPath;

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check the [Releases](https://github.com/sdatkinson/NeuralAmpModelerPlugin/releas
 
 ## Supported Platforms
 
-The Neural Amp Modeler plugin currently supports Windows 10 (64bit) or later, and MacOs 10.15 (Catalina) or later.
+The Neural Amp Modeler plugin currently supports Windows 10 (64bit) or later, and macOS 10.15 (Catalina) or later.
 
 For Linux support, there is an LV2 plugin available: https://github.com/mikeoliphant/neural-amp-modeler-lv2.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ A VST3/AudioUnit plug-in\* for [Neural Amp Modeler](https://github.com/sdatkinso
 
 Check the [Releases](https://github.com/sdatkinson/NeuralAmpModelerPlugin/releases) for pre-built installers for the plugin!
 
+## Supported Platforms
+
+The Neural Amp Modeler plugin currently supports Windows 10 (64bit) or later, and MacOs 10.15 (Catalina) or later.
+
+For Linux support, there is an LV2 plugin available: https://github.com/mikeoliphant/neural-amp-modeler-lv2.
+
 ## About
 
 This is a cleaned up version of [the original iPlug2-based NAM plugin](https://github.com/sdatkinson/iPlug2) with some refactoring to adopt better practices recommended by the developers of iPlug2.


### PR DESCRIPTION
This fixes loading models with utf8 characters (ie: **ß**) in the path.

This comes up a lot as a problem in the Facebook group.