### PR TITLE
Set output normalization state disable state correctly on DAW startup

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -670,21 +670,28 @@ void NeuralAmpModeler::_ApplyDSPStaging()
     this->_UnsetIRMsg();
     this->mFlagRemoveIR = false;
   }
-  if (this->mFlagSetDisableNormalization) {
-    try {
+  if (this->mFlagSetDisableNormalization)
+  {
+    try
+    {
       // Disable Normalization toggle when no loudness data in model metadata
       // Sometimes the UI isn't initialized, so we have to try again later.
       auto ui = GetUI();
-      if (ui != nullptr) {
+      if (ui != nullptr)
+      {
         auto c = ui->GetControlWithTag(kOutNorm);
-        if (c != nullptr) {
+        if (c != nullptr)
+        {
           c->SetDisabled(this->mSetDisableNormalization);
-          if (c->IsDisabled() == this->mSetDisableNormalization){
+          if (c->IsDisabled() == this->mSetDisableNormalization)
+          {
             this->mFlagSetDisableNormalization = false;
           }
         }
       }
-    } catch (std::runtime_error &e) {
+    }
+    catch (std::runtime_error& e)
+    {
     }
   }
 }

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -113,6 +113,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
 , mStagedIR(nullptr)
 , mFlagRemoveNAM(false)
 , mFlagRemoveIR(false)
+, mFlagSetDisableNormalization(false)
+, mSetDisableNormalization(false)
 , mDefaultNAMString("Select model...")
 , mDefaultIRString("Select IR...")
 , mToneBass()
@@ -645,8 +647,8 @@ void NeuralAmpModeler::_ApplyDSPStaging()
     // Move from staged to active DSP
     this->mNAM = std::move(this->mStagedNAM);
     this->mStagedNAM = nullptr;
-    // Disable Normalization toggle when no loudness data in model metadata
-    GetUI()->GetControlWithTag(kOutNorm)->SetDisabled(!mNAM->HasLoudness());
+    this->mFlagSetDisableNormalization = true;
+    this->mSetDisableNormalization = !mNAM->HasLoudness();
   }
   if (this->mStagedIR != nullptr)
   {
@@ -667,6 +669,23 @@ void NeuralAmpModeler::_ApplyDSPStaging()
     this->mIRPath.Set("");
     this->_UnsetIRMsg();
     this->mFlagRemoveIR = false;
+  }
+  if (this->mFlagSetDisableNormalization) {
+    try {
+      // Disable Normalization toggle when no loudness data in model metadata
+      // Sometimes the UI isn't initialized, so we have to try again later.
+      auto ui = GetUI();
+      if (ui != nullptr) {
+        auto c = ui->GetControlWithTag(kOutNorm);
+        if (c != nullptr) {
+          c->SetDisabled(this->mSetDisableNormalization);
+          if (c->IsDisabled() == this->mSetDisableNormalization){
+            this->mFlagSetDisableNormalization = false;
+          }
+        }
+      }
+    } catch (std::runtime_error &e) {
+    }
   }
 }
 

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -142,6 +142,10 @@ private:
   bool mFlagRemoveIR;
   const WDL_String mDefaultNAMString;
   const WDL_String mDefaultIRString;
+  
+  // Try to set the diable state of output normalization
+  bool mFlagSetDisableNormalization;
+  bool mSetDisableNormalization;  // True = Disable
 
   // Tone stack modules
   recursive_linear_filter::LowShelf mToneBass;

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -142,10 +142,10 @@ private:
   bool mFlagRemoveIR;
   const WDL_String mDefaultNAMString;
   const WDL_String mDefaultIRString;
-  
+
   // Try to set the diable state of output normalization
   bool mFlagSetDisableNormalization;
-  bool mSetDisableNormalization;  // True = Disable
+  bool mSetDisableNormalization; // True = Disable
 
   // Tone stack modules
   recursive_linear_filter::LowShelf mToneBass;


### PR DESCRIPTION
Resolves #199 and stops Reaper from crashing on startup when loading a project that's got a NAM with a model!