### PR TITLE
Make plugin truly mono

### DIFF
--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -14,7 +14,7 @@
 
 #define SHARED_RESOURCES_SUBPATH "NeuralAmpModeler"
 
-#define PLUG_CHANNEL_IO "1-1 1-2"
+#define PLUG_CHANNEL_IO "1-1"
 
 #define PLUG_LATENCY 0
 #define PLUG_TYPE 0


### PR DESCRIPTION
Currently the plugin is not really mono - it is "1 > 2". This change makes it truly mono, which makes more sense, as no stereo processing is currently going on.

To verify, when loading in Reaper you can see "(mono)" after it.

Most hosts are pretty good about handling things, but making the plugin explicitly mono may help inform the host. It also should avoid the cheap, but unnecessary copy of output to the second channel.

Btw, I think we *should* support stereo workflows (perhaps providing both mono and stereo versions of the plugin), but that will require more work (mostly just UI).