### PR TITLE
Fix macOS app resizing

### DIFF
--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -28,10 +28,8 @@
 #define PLUG_FPS 60
 #define PLUG_SHARED_RESOURCES 0
 #define PLUG_HOST_RESIZE 0
-#define PLUG_MIN_WIDTH 250
-#define PLUG_MIN_HEIGHT 150
-#define PLUG_MAX_WIDTH 1000
-#define PLUG_MAX_HEIGHT 600
+#define PLUG_MAX_WIDTH PLUG_WIDTH * 4
+#define PLUG_MAX_HEIGHT PLUG_HEIGHT * 4
 
 #define AUV2_ENTRY NeuralAmpModeler_Entry
 #define AUV2_ENTRY_STR "NeuralAmpModeler_Entry"


### PR DESCRIPTION
On macOS, resizing the UI would start moving it when it hit the limits. Increasing the limits prevents this. Might be a better fix in iPlug2 code, but this works for now.