### PR TITLE
Specify mono->stereo I/O for standalone app build

### DIFF
--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -14,7 +14,11 @@
 
 #define SHARED_RESOURCES_SUBPATH "NeuralAmpModeler"
 
+#ifdef APP_API
+#define PLUG_CHANNEL_IO "1-2"
+#else
 #define PLUG_CHANNEL_IO "1-1 1-2 2-2"
+#endif
 
 #define PLUG_LATENCY 0
 #define PLUG_TYPE 0


### PR DESCRIPTION
Many macOS machines only have mono input and so the default channel IO will fail meaning the app audio will not start. Customizing the I/O for the app build fixes thist