### PR TITLE
Run build action on push or pull_request

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,7 +1,10 @@
 name: Build Native
 
 on:
-  [workflow_dispatch, push, pull_request]
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 2'
   #push:
     # tags:
     #   - "v*"

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,7 +1,7 @@
 name: Build Native
 
 on:
-  workflow_dispatch
+  [workflow_dispatch, push, pull_request]
   #push:
     # tags:
     #   - "v*"


### PR DESCRIPTION
The PR makes the "Build Native" github action run on push and on pull request.

This is useful for a number of reasons:

 - it verifies that a pull request does not break the build
 - it makes it easy to test the result of a PR by grabbing the resulting artifacts
 - it effectively creates "snapshot" releases for people who want to try the latest version, but can't build themselves
