### PR TITLE
Select file (model, IR) directory instead of a single file

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -224,11 +224,11 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     };
 
     pGraphics->AttachControl(
-      new NAMFileBrowserControl(modelArea, kMsgTagClearModel, "Select model...", "nam", loadModelCompletionHandler,
+      new NAMFileBrowserControl(modelArea, kMsgTagClearModel, "Select model directory...", "nam", loadModelCompletionHandler,
                                 style, fileSVG, closeButtonSVG, leftArrowSVG, rightArrowSVG),
       kCtrlTagModelFileBrowser);
     pGraphics->AttachControl(
-      new NAMFileBrowserControl(irArea, kMsgTagClearIR, "Select IR...", "wav", loadIRCompletionHandler, style, fileSVG,
+      new NAMFileBrowserControl(irArea, kMsgTagClearIR, "Select IR directory...", "wav", loadIRCompletionHandler, style, fileSVG,
                                 closeButtonSVG, leftArrowSVG, rightArrowSVG),
       kCtrlTagIRFileBrowser);
 

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -203,14 +203,14 @@ public:
       WDL_String fileName;
       WDL_String path;
       GetSelectedFileDirectory(path);
-      pCaller->GetUI()->PromptForFile(
-        fileName, path, EFileAction::Open, mExtension.Get(), [&](const WDL_String& fileName, const WDL_String& path) {
-          if (fileName.GetLength())
+      pCaller->GetUI()->PromptForDirectory(
+        path, [&](const WDL_String& fileName, const WDL_String& path) {
+          if (path.GetLength())
           {
             ClearPathList();
             AddPath(path.Get(), "");
             SetupMenu();
-            SetSelectedFile(fileName.Get());
+            SelectFirstFile();
             LoadFileAtCurrentIndex();
           }
         });
@@ -297,6 +297,11 @@ public:
   }
 
 private:
+  void SelectFirstFile()
+  {
+    mSelectedIndex = mFiles.GetSize() ? 0 : -1;
+  }
+  
   void GetSelectedFileDirectory(WDL_String& path) {
     GetSelectedFile(path);
     path.remove_filepart();


### PR DESCRIPTION
Resolves #281 by giving NAM the permission for all of the directory at once.

Picks the first model in the directory to start; use arrows/dropdown menu to go from there.

Known issue: if the first file in the directory is invalid (e.g. a stereo IR), then this doesn't work cf #285 (will fix next)