### PR TITLE
Don't recurse down file directories when collecting files to iterate through

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "iPlug2"]
 	path = iPlug2
-	url = https://github.com/iPlug2/iPlug2
+	# url = https://github.com/iPlug2/iPlug2  # For being steady
+	url = https://github.com/sdatkinson/iPlug2.git  # For moving fast
 [submodule "eigen"]
 	path = eigen
 	url = https://gitlab.com/libeigen/eigen.git

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -224,11 +224,11 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     };
 
     pGraphics->AttachControl(
-      new NAMFileBrowserControl(modelArea, kMsgTagClearModel, "Select model...", "nam", loadModelCompletionHandler,
+      new NAMFileBrowserControl(modelArea, kMsgTagClearModel, "Select model directory...", "nam", loadModelCompletionHandler,
                                 style, fileSVG, closeButtonSVG, leftArrowSVG, rightArrowSVG),
       kCtrlTagModelFileBrowser);
     pGraphics->AttachControl(
-      new NAMFileBrowserControl(irArea, kMsgTagClearIR, "Select IR...", "wav", loadIRCompletionHandler, style, fileSVG,
+      new NAMFileBrowserControl(irArea, kMsgTagClearIR, "Select IR directory...", "wav", loadIRCompletionHandler, style, fileSVG,
                                 closeButtonSVG, leftArrowSVG, rightArrowSVG),
       kCtrlTagIRFileBrowser);
 

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -272,9 +272,11 @@ public:
     switch (msgTag)
     {
       case kMsgTagLoadFailed:
-        ClearPathList();
-        SetupMenu();
-        mFileNameControl->SetLabelAndTooltip("Load Failed");
+        // Honestly, not sure why I made a big stink of it before. Why not just say it failed and move on? :)
+        {
+          std::string label(std::string("(FAILED) ") + std::string(mFileNameControl->GetLabelStr()));
+          mFileNameControl->SetLabelAndTooltip(label.c_str());
+        }
         break;
       case kMsgTagLoadedModel:
       case kMsgTagLoadedIR:

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -203,14 +203,14 @@ public:
       WDL_String fileName;
       WDL_String path;
       GetSelectedFileDirectory(path);
-      pCaller->GetUI()->PromptForFile(
-        fileName, path, EFileAction::Open, mExtension.Get(), [&](const WDL_String& fileName, const WDL_String& path) {
-          if (fileName.GetLength())
+      pCaller->GetUI()->PromptForDirectory(
+        path, [&](const WDL_String& fileName, const WDL_String& path) {
+          if (path.GetLength())
           {
             ClearPathList();
             AddPath(path.Get(), "");
             SetupMenu();
-            SetSelectedFile(fileName.Get());
+            SelectFirstFile();
             LoadFileAtCurrentIndex();
           }
         });
@@ -297,6 +297,11 @@ public:
   }
 
 private:
+  void SelectFirstFile()
+  {
+    mSelectedIndex = mFiles.GetSize() ? 0 : -1;
+  }
+  
   void GetSelectedFileDirectory(WDL_String& path) {
     GetSelectedFile(path);
     path.remove_filepart();

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "IControls.h"
-#include "dirscan.h"  // WDL_DirScan
 
 using namespace iplug;
 using namespace igraphics;
@@ -297,55 +296,6 @@ public:
       }
       default: break;
     }
-  }
-  
-  // Don't recurse.
-  // TODO Issue & PR iPlug2
-  void ScanDirectory(const char* path, IPopupMenu& menuToAddTo) override
-  {
-    const bool recursive = false;
-    WDL_DirScan d;
-    
-    if (!d.First(path))
-    {
-      do
-      {
-        const char* f = d.GetCurrentFN();
-        if (f && f[0] != '.')
-        {
-          if (d.GetCurrentIsDirectory())
-          {
-            if (recursive) {
-              WDL_String subdir;
-              d.GetCurrentFullFN(&subdir);
-              IPopupMenu* pNewMenu = new IPopupMenu();
-              menuToAddTo.AddItem(d.GetCurrentFN(), pNewMenu, -2);
-              ScanDirectory(subdir.Get(), *pNewMenu);
-            }
-          }
-          else
-          {
-            const char* a = strstr(f, mExtension.Get());
-            if (a && a > f && strlen(a) == strlen(mExtension.Get()))
-            {
-              WDL_String menuEntry {f};
-              
-              if(!mShowFileExtensions)
-                menuEntry.Set(f, (int) (a - f) - 1);
-              
-              IPopupMenu::Item* pItem = new IPopupMenu::Item(menuEntry.Get(), IPopupMenu::Item::kNoFlags, mFiles.GetSize());
-              menuToAddTo.AddItem(pItem, -2 /* sort alphabetically */);
-              WDL_String* pFullPath = new WDL_String("");
-              d.GetCurrentFullFN(pFullPath);
-              mFiles.Add(pFullPath);
-            }
-          }
-        }
-      } while (!d.Next());
-    }
-    
-    if (!mShowEmptySubmenus)
-      menuToAddTo.RemoveEmptySubmenus();
   }
 
 private:


### PR DESCRIPTION
This PR resolves #282 by stopping `NAMFileBrowserControl::ScanDirectory()` from recusing down subdirectories. The result is also more in line with the experience that I'd like thee to be.