### PR TITLE
Open files on all targets except macOS standalone

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -223,12 +223,19 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
       }
     };
 
-    pGraphics->AttachControl(new NAMFileBrowserControl(modelArea, kMsgTagClearModel, "Select model directory...", "nam",
-                                                       loadModelCompletionHandler, style, fileSVG, closeButtonSVG,
-                                                       leftArrowSVG, rightArrowSVG),
+#ifdef NAM_PICK_DIRECTORY
+    const std::string defaultNamFileString = "Select model directory...";
+    const std::string defaultIRString = "Select IR directory...";
+#else
+    const std::string defaultNamFileString = "Select model...";
+    const std::string defaultIRString = "Select IR...";
+#endif
+    pGraphics->AttachControl(new NAMFileBrowserControl(modelArea, kMsgTagClearModel, defaultNamFileString.c_str(),
+                                                       "nam", loadModelCompletionHandler, style, fileSVG,
+                                                       closeButtonSVG, leftArrowSVG, rightArrowSVG),
                              kCtrlTagModelFileBrowser);
     pGraphics->AttachControl(
-      new NAMFileBrowserControl(irArea, kMsgTagClearIR, "Select IR directory...", "wav", loadIRCompletionHandler, style,
+      new NAMFileBrowserControl(irArea, kMsgTagClearIR, defaultIRString.c_str(), "wav", loadIRCompletionHandler, style,
                                 fileSVG, closeButtonSVG, leftArrowSVG, rightArrowSVG),
       kCtrlTagIRFileBrowser);
 

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -202,6 +202,7 @@ public:
       WDL_String fileName;
       WDL_String path;
       GetSelectedFileDirectory(path);
+#ifdef NAM_PICK_DIRECTORY
       pCaller->GetUI()->PromptForDirectory(path, [&](const WDL_String& fileName, const WDL_String& path) {
         if (path.GetLength())
         {
@@ -212,6 +213,19 @@ public:
           LoadFileAtCurrentIndex();
         }
       });
+#else
+      pCaller->GetUI()->PromptForFile(
+        fileName, path, EFileAction::Open, mExtension.Get(), [&](const WDL_String& fileName, const WDL_String& path) {
+          if (fileName.GetLength())
+          {
+            ClearPathList();
+            AddPath(path.Get(), "");
+            SetupMenu();
+            SetSelectedFile(fileName.Get());
+            LoadFileAtCurrentIndex();
+          }
+        });
+#endif
     };
 
     auto clearFileFunc = [&](IControl* pCaller) {

--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -73,3 +73,11 @@
 #define TOGGLEIR2X_FN "SkinEHeritage_IR_Toggle@2x.png"
 #define TOGGLE_HANDLE_FN "SkinEHeritage_ToggleHandle.png"
 #define TOGGLE_HANDLE2X_FN "SkinEHeritage_ToggleHandle@2x.png"
+
+// Issue 291
+// On the macOS standalone, we might not have permissions to traverse the file directory, so we have the app ask the
+// user to pick a directory instead of the file in the directory.
+// Everyone else is fine though.
+#if defined(APP_API) && defined(__APPLE__)
+  #define NAM_PICK_DIRECTORY
+#endif


### PR DESCRIPTION
Resolves #291 as much as possible by reverting behavior to picking files wherever possible.

The only exception is macOS standalone, where the app wouldn't have the required permissions for the arrows to work. So, I'm picking what I think is the lesser of two evils and having it stay with picking directories. At least users can two-finger scroll there...