### PR TITLE
Set chosen item in popup menu

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -242,6 +242,7 @@ public:
       else
       {
         CheckSelectedItem();
+        mMainMenu.SetChosenItemIdx(mSelectedIndex);
         pCaller->GetUI()->CreatePopupMenu(*this, mMainMenu, pCaller->GetRECT());
       }
     };


### PR DESCRIPTION
This means that on macOS the menu will pop-up highlighting the selected file in the middle, otherwise the menu starts at the mouse click position, which is very annoying if there are a lot of files in the directory.

@sdatkinson Not sure how this change slipped the original PR but it's important!