### PR TITLE
Get expected sample rate from model for warning message

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -517,14 +517,18 @@ void NeuralAmpModeler::_CheckSampleRateWarning()
 {
   if (auto* pGraphics = GetUI())
   {
+    auto* control = pGraphics->GetControlWithTag(kCtrlTagSampleRateWarning)->As<NAMSampleRateWarningControl>();
     bool showWarning = false;
     if (_HaveModel())
     {
       const auto pluginSampleRate = GetSampleRate();
-      const double namSampleRate = 48000.0; // TODO from model
+      const auto namSampleRateFromModel = mModel->GetExpectedSampleRate();
+      // Any model with "-1" is probably 48k
+      const auto namSampleRate = namSampleRateFromModel == -1.0 ? 48000.0 : namSampleRateFromModel;
+      control->SetSampleRate(namSampleRate);
       showWarning = pluginSampleRate != namSampleRate;
     }
-    pGraphics->GetControlWithTag(kCtrlTagSampleRateWarning)->SetDisabled(!showWarning);
+    control->SetDisabled(!showWarning);
     mCheckSampleRateWarning = false;
   }
 }

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <sstream>
-#include <string>
+#include <cmath> // std::round
+#include <sstream> // std::stringstream
 #include "IControls.h"
 
 #define PLUG() static_cast<PLUG_CLASS_NAME*>(GetDelegate())

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sstream>
+#include <string>
 #include "IControls.h"
 
 #define PLUG() static_cast<PLUG_CLASS_NAME*>(GetDelegate())
@@ -436,10 +438,11 @@ class NAMSampleRateWarningControl : public ITextControl
 {
 public:
   NAMSampleRateWarningControl(const IRECT& bounds)
-  : ITextControl(bounds, "WARNING: Run NAM at sample rate 48kHz!", _WARNING_TEXT)
+  : ITextControl(bounds, "", _WARNING_TEXT)
   {
     // Default to disabled so that we don't get a flash every time we open the UI.
     SetDisabled(true);
+    SetSampleRate(48000.0);
   }
   void SetDisabled(bool disable) override
   {
@@ -448,6 +451,14 @@ public:
       mDisabled = disable;
       SetDirty(false);
     }
+  }
+  // Adjust what's displayed according to the provided smalpe rate.
+  // Assumes that the given value is valid.
+  void SetSampleRate(const double sampleRate)
+  {
+    std::stringstream ss;
+    ss << "WARNING: NAM model expects sample rate " << static_cast<long>(std::round(sampleRate));
+    SetStr(ss.str().c_str());
   }
 
 protected:


### PR DESCRIPTION
Instead of assuming all models like 48k, this looks for the information in the NAM model exposed via `GetExpectedSampleRate()` thanks to #303 😄 