### PR TITLE
Apply high-pass filter to remove DC offset present in some models

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -166,6 +166,10 @@ private:
   recursive_linear_filter::Peaking mToneMid;
   recursive_linear_filter::HighShelf mToneTreble;
 
+  // Post-IR filters
+  recursive_linear_filter::HighPass mHighPass;
+  //  recursive_linear_filter::LowPass mLowPass;
+
   // Path to model's config.json or model.nam
   WDL_String mNAMPath;
   // Path to IR (.wav file)


### PR DESCRIPTION
Applies a low-frequency HPF to the output, removing the DC offset that can exist in a model.

Resolves #271.