### PR TITLE
Add file manager class & keyboard navigation

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -195,13 +195,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     pGraphics->AttachControl(new IVLabelControl(titleArea, "NEURAL AMP MODELER", titleStyle));
     pGraphics->AttachControl(new ISVGControl(modelIconArea, modelIconSVG));
 
-#ifdef NAM_PICK_DIRECTORY
     const std::string defaultNamFileString = "Select model directory...";
     const std::string defaultIRString = "Select IR directory...";
-#else
-    const std::string defaultNamFileString = "Select model...";
-    const std::string defaultIRString = "Select IR...";
-#endif
     pGraphics->AttachControl(new NAMFileBrowserControl(modelArea, mModelFileManager, kMsgTagClearModel, defaultNamFileString.c_str(), style, fileSVG, crossSVG,
                                                        leftArrowSVG, rightArrowSVG, fileBackgroundBitmap),
                              kCtrlTagModelFileBrowser);

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -170,6 +170,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
         std::cout << "Loaded: " << fileName.Get() << std::endl;
       }
     };
+    mModelFileManager.SetCompletionHandler(loadModelCompletionHandler);
 
     // IR loader button
     auto loadIRCompletionHandler = [&](const WDL_String& fileName, const WDL_String& path) {
@@ -187,6 +188,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
         }
       }
     };
+    mIRFileManager.SetCompletionHandler(loadIRCompletionHandler);
 
     pGraphics->AttachBackground(BACKGROUND_FN);
     pGraphics->AttachControl(new IBitmapControl(b, linesBitmap));
@@ -200,13 +202,12 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     const std::string defaultNamFileString = "Select model...";
     const std::string defaultIRString = "Select IR...";
 #endif
-    pGraphics->AttachControl(new NAMFileBrowserControl(modelArea, kMsgTagClearModel, defaultNamFileString.c_str(),
-                                                       "nam", loadModelCompletionHandler, style, fileSVG, crossSVG,
+    pGraphics->AttachControl(new NAMFileBrowserControl(modelArea, mModelFileManager, kMsgTagClearModel, defaultNamFileString.c_str(), style, fileSVG, crossSVG,
                                                        leftArrowSVG, rightArrowSVG, fileBackgroundBitmap),
                              kCtrlTagModelFileBrowser);
     pGraphics->AttachControl(new ISVGSwitchControl(irSwitchArea, {irIconOffSVG, irIconOnSVG}, kIRToggle));
     pGraphics->AttachControl(
-      new NAMFileBrowserControl(irArea, kMsgTagClearIR, defaultIRString.c_str(), "wav", loadIRCompletionHandler, style,
+      new NAMFileBrowserControl(irArea, mIRFileManager, kMsgTagClearIR, defaultIRString.c_str(), style,
                                 fileSVG, crossSVG, leftArrowSVG, rightArrowSVG, fileBackgroundBitmap),
       kCtrlTagIRFileBrowser);
     pGraphics->AttachControl(new NAMSwitchControl(ngToggleArea, kNoiseGateActive, " ", style, switchHandleBitmap));
@@ -248,6 +249,37 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     });
 
     pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetMouseEventsWhenDisabled(false);
+    
+    pGraphics->SetKeyHandlerFunc([&, pGraphics](const IKeyPress& key, bool isUp){
+      if (!isUp)
+      {
+        if (key.VK == kVK_LEFT)
+        {
+          mModelFileManager.PreviousFile();
+          pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser)->As<NAMFileBrowserControl>()->PreviousFile();
+          return true;
+        }
+        else if (key.VK == kVK_RIGHT)
+        {
+          mModelFileManager.NextFile();
+          pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser)->As<NAMFileBrowserControl>()->NextFile();
+          return true;
+        }
+        if (key.VK == kVK_UP)
+        {
+          mIRFileManager.PreviousFile();
+          pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser)->As<NAMFileBrowserControl>()->PreviousFile();
+          return true;
+        }
+        else if (key.VK == kVK_DOWN)
+        {
+          mIRFileManager.NextFile();
+          pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser)->As<NAMFileBrowserControl>()->NextFile();
+          return true;
+        }
+      }
+      return false;
+    });
   };
 }
 

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -9,8 +9,7 @@
 
 #include "IPlug_include_in_plug_hdr.h"
 #include "ISender.h"
-#define M_PI 3.141592653589793238462643383279 // Needed by NonIntegerResampler.h
-#include "NonIntegerResampler.h"
+#include "RealtimeResampler.h"
 
 const int kNumPresets = 1;
 // The plugin is mono inside
@@ -189,7 +188,7 @@ private:
   bool mFinalized = true;
 
   // The resampling wrapper
-  iplug::NonIntegerResampler<NAM_SAMPLE, 1> mResampler;
+  iplug::RealtimeResampler<NAM_SAMPLE, 1, 12> mResampler;
 
   // Used to check that we don't get too large a block to process.
   int mMaxExternalBlockSize = 0;

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -11,6 +11,8 @@
 #include "ISender.h"
 #include "RealtimeResampler.h"
 
+#include "NeuralAmpModelerFileManager.h"
+
 const int kNumPresets = 1;
 // The plugin is mono inside
 constexpr size_t kNumChannelsInternal = 1;
@@ -316,4 +318,5 @@ private:
   std::unordered_map<std::string, double> mNAMParams = {{"Input", 0.0}, {"Output", 0.0}};
 
   NAMSender mInputSender, mOutputSender;
+  FileManager mModelFileManager {"nam"}, mIRFileManager {"wav"};
 };

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -304,7 +304,11 @@ public:
       else
       {
         CheckSelectedItem();
-        mMainMenu.SetChosenItemIdx(mSelectedItemIndex);
+        
+        if (!mMainMenu.HasSubMenus())
+        {
+          mMainMenu.SetChosenItemIdx(mSelectedItemIndex);
+        }
         pCaller->GetUI()->CreatePopupMenu(*this, mMainMenu, pCaller->GetRECT());
       }
     };

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -255,11 +255,7 @@ public:
         mFileManager.OnPicked(fileName, path, true);
       };
       
-#ifdef NAM_PICK_DIRECTORY
       pCaller->GetUI()->PromptForDirectory(path, callbackFunc);
-#else
-      pCaller->GetUI()->PromptForFile(fileName, path, EFileAction::Open, mFileManager.GetExtension(), callbackFunc);
-#endif
     };
 
     auto clearFileFunc = [&](IControl* pCaller) {

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -228,7 +228,7 @@ public:
 
       if (pItem)
       {
-        mSelectedIndex = mItems.Find(pItem);
+        mSelectedItemIndex = mItems.Find(pItem);
         LoadFileAtCurrentIndex();
       }
     }
@@ -240,10 +240,10 @@ public:
       const auto nItems = NItems();
       if (nItems == 0)
         return;
-      mSelectedIndex--;
+      mSelectedItemIndex--;
 
-      if (mSelectedIndex < 0)
-        mSelectedIndex = nItems - 1;
+      if (mSelectedItemIndex < 0)
+        mSelectedItemIndex = nItems - 1;
 
       LoadFileAtCurrentIndex();
     };
@@ -252,10 +252,10 @@ public:
       const auto nItems = NItems();
       if (nItems == 0)
         return;
-      mSelectedIndex++;
+      mSelectedItemIndex++;
 
-      if (mSelectedIndex >= nItems)
-        mSelectedIndex = 0;
+      if (mSelectedItemIndex >= nItems)
+        mSelectedItemIndex = 0;
 
       LoadFileAtCurrentIndex();
     };
@@ -304,7 +304,7 @@ public:
       else
       {
         CheckSelectedItem();
-        mMainMenu.SetChosenItemIdx(mSelectedIndex);
+        mMainMenu.SetChosenItemIdx(mSelectedItemIndex);
         pCaller->GetUI()->CreatePopupMenu(*this, mMainMenu, pCaller->GetRECT());
       }
     };
@@ -333,7 +333,7 @@ public:
 
   void LoadFileAtCurrentIndex()
   {
-    if (mSelectedIndex > -1 && mSelectedIndex < NItems())
+    if (mSelectedItemIndex > -1 && mSelectedItemIndex < NItems())
     {
       WDL_String fileName, path;
       GetSelectedFile(fileName);
@@ -373,7 +373,7 @@ public:
   }
 
 private:
-  void SelectFirstFile() { mSelectedIndex = mFiles.GetSize() ? 0 : -1; }
+  void SelectFirstFile() { mSelectedItemIndex = mFiles.GetSize() ? 0 : -1; }
 
   void GetSelectedFileDirectory(WDL_String& path)
   {

--- a/NeuralAmpModeler/NeuralAmpModelerFileManager.h
+++ b/NeuralAmpModeler/NeuralAmpModelerFileManager.h
@@ -1,0 +1,270 @@
+#pragma once
+
+#include "dirscan.h"
+#include "wdlstring.h"
+#include <functional>
+#include <string_view>
+#include <filesystem>
+
+using CompletionHandlerFunc = std::function<void(const WDL_String&, const WDL_String&)>;
+
+using namespace iplug::igraphics;
+
+class FileManager
+{
+public:
+  /** Creates a FileManager
+   * @param bounds The control's bounds
+   * @param extension The file extenstion to browse for, e.g excluding the dot e.g. "txt"
+   * @param showFileExtension Should the menu show the file extension
+   * @param scanRecursively Should the paths be scanned recursively, creating submenus
+   * @param showEmptySubmenus If scanRecursively, should empty folders be shown in the menu */
+  FileManager(const char* extension, bool showFileExtensions = true, bool scanRecursively = true, bool showEmptySubmenus = false)
+  : mExtension(extension)
+  , mShowFileExtensions(showFileExtensions)
+  , mScanRecursively(scanRecursively)
+  , mShowEmptySubmenus(showEmptySubmenus)
+  {
+    mMainMenu.SetRootTitle(std::string_view(extension) == "nam" ? "Models" : "IRs");
+  }
+
+  ~FileManager()
+  {
+    ClearItems();
+  }
+  
+  IPopupMenu& GetMenu() { return mMainMenu; }
+  
+  void OnPicked(const WDL_String& fileName, const WDL_String& path, bool loadFile = false)
+  {
+    if (path.GetLength())
+    {
+      ClearItems();
+      mPath.Set(path.Get());
+      SetupMenu();
+      fileName.GetLength() ? SelectFileWithPath(fileName.Get()) : SelectFirstFile();
+      
+      if (loadFile)
+        LoadFileAtCurrentIndex();
+    }
+  }
+
+  int NItems() const
+  {
+    return mItems.GetSize();
+  }
+  
+  void SelectFileWithItem(IPopupMenu::Item* pItem)
+  {
+    mSelectedIndex = mItems.Find(pItem);
+  }
+
+  void SelectFirstFile() { mSelectedIndex = mFiles.GetSize() ? 0 : -1; }
+
+  void SelectFileWithPath(const char* filePath)
+  {
+    for (auto fileIdx = 0; fileIdx < mFiles.GetSize(); fileIdx ++)
+    {
+      if (strcmp(mFiles.Get(fileIdx)->Get(), filePath) == 0)
+      {
+        for (auto itemIdx = 0; itemIdx < mItems.GetSize(); itemIdx++)
+        {
+          IPopupMenu::Item* pItem = mItems.Get(itemIdx);
+
+          if (pItem->GetTag() == fileIdx)
+          {
+            mSelectedIndex = itemIdx;
+            return;
+          }
+        }
+      }
+    }
+    
+    mSelectedIndex = -1;
+  }
+
+  void GetSelectedFile(WDL_String& path) const
+  {
+    if (mSelectedIndex > -1)
+    {
+      IPopupMenu::Item* pItem = mItems.Get(mSelectedIndex);
+      path.Set(mFiles.Get(pItem->GetTag()));
+    }
+    else
+    {
+      path.Set("");
+    }
+  }
+
+  const char* GetExtension() const
+  {
+    return mExtension.Get();
+  }
+  
+  void CheckSelectedItem()
+  {
+    if (mSelectedIndex > -1)
+    {
+      mMainMenu.SetChosenItemIdx(mSelectedIndex);
+      IPopupMenu::Item* pItem = mItems.Get(mSelectedIndex);
+      mMainMenu.CheckItemAlone(pItem);
+    }
+  }
+
+  void PreviousFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedIndex--;
+
+    if (mSelectedIndex < 0)
+      mSelectedIndex = nItems - 1;
+
+    LoadFileAtCurrentIndex();
+  }
+
+  void NextFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedIndex++;
+
+    if (mSelectedIndex >= nItems)
+      mSelectedIndex = 0;
+
+    LoadFileAtCurrentIndex();
+  }
+  
+  void LoadFileAtCurrentIndex()
+  {
+    if (mSelectedIndex > -1 && mSelectedIndex < NItems())
+    {
+      WDL_String fileName, path;
+      GetSelectedFile(fileName);
+      mCompletionHandler(fileName, path);
+    }
+  }
+  
+  void SetCompletionHandler(CompletionHandlerFunc completionHandler) {
+    mCompletionHandler = completionHandler;
+  }
+  
+  void SetDefaultPath(const char* path) { mDefaultPath.Set(path); }
+  const char* GetDefaultPath() const { return mDefaultPath.Get(); }
+  
+#pragma mark - Private methods:
+  
+private:
+
+  void CollectSortedItems(IPopupMenu* pMenu)
+  {
+    int nItems = pMenu->NItems();
+    
+    for (int i = 0; i < nItems; i++)
+    {
+      IPopupMenu::Item* pItem = pMenu->GetItem(i);
+      
+      if (pItem->GetSubmenu())
+        CollectSortedItems(pItem->GetSubmenu());
+      else
+        mItems.Add(pItem);
+    }
+  }
+
+  void SetupMenu()
+  {
+    mFiles.Empty(true);
+    mItems.Empty(false);
+    
+    mMainMenu.Clear();
+    mSelectedIndex = -1;
+
+    ScanDirectory(mPath.Get(), mMainMenu);
+    CollectSortedItems(&mMainMenu);
+  }
+
+  void ClearItems()
+  {
+    mFiles.Empty(true);
+    mItems.Empty(false);
+  }
+
+  void ScanDirectory(const char* path, IPopupMenu& menuToAddTo)
+  {
+    WDL_DirScan d;
+
+    if (!d.First(path))
+    {
+      do
+      {
+        const char* f = d.GetCurrentFN();
+
+        if (f)
+        {
+          std::filesystem::path path(f);
+
+          if (f[0] != '.' && mScanRecursively && d.GetCurrentIsDirectory())
+          {
+            WDL_String subdir;
+            d.GetCurrentFullFN(&subdir);
+            IPopupMenu* pNewMenu = new IPopupMenu();
+            menuToAddTo.AddItem(d.GetCurrentFN(), pNewMenu, -2);
+            ScanDirectory(subdir.Get(), *pNewMenu);
+          }
+          else
+          {
+            auto extensionWithDot = std::string(".") + std::string(mExtension.Get());
+
+            if (path.extension() == extensionWithDot || path.extension() == ".icloud")
+            {
+              if (path.extension() == ".icloud")
+              {
+                auto newPath = path.replace_extension("");
+                
+                if (newPath.extension() == extensionWithDot)
+                {
+                  path = newPath.replace_filename(newPath.filename().string().substr(1));
+                }
+                else
+                {
+                  break;
+                }
+              }
+
+              {
+                WDL_String menuEntry {path.c_str()};
+                
+                if (!mShowFileExtensions)
+                  menuEntry.remove_fileext();
+                
+                IPopupMenu::Item* pItem = new IPopupMenu::Item(menuEntry.Get(), IPopupMenu::Item::kNoFlags, mFiles.GetSize());
+                menuToAddTo.AddItem(pItem, -2 /* sort alphabetically */);
+                WDL_String* pFullPath = new WDL_String("");
+                d.GetCurrentFullFN(pFullPath);
+                mFiles.Add(pFullPath);
+              }
+            }
+          }
+        }
+      } while (!d.Next());
+    }
+
+    if (!mShowEmptySubmenus)
+      menuToAddTo.RemoveEmptySubmenus();
+  }
+
+private:
+  CompletionHandlerFunc mCompletionHandler;
+  const bool mScanRecursively;
+  const bool mShowFileExtensions;
+  const bool mShowEmptySubmenus;
+  int mSelectedIndex = -1;
+  IPopupMenu mMainMenu;
+  WDL_String mPath;
+  WDL_PtrList<WDL_String> mFiles;
+  WDL_PtrList<IPopupMenu::Item> mItems; // ptr to item for each file
+  WDL_String mExtension;
+  WDL_String mDefaultPath;
+};

--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -87,11 +87,3 @@
 #define METERBACKGROUND_FN "MeterBackground.png"
 #define METERBACKGROUND2X_FN "MeterBackground@2x.png"
 #define METERBACKGROUND3X_FN "MeterBackground@3x.png"
-
-// Issue 291
-// On the macOS standalone, we might not have permissions to traverse the file directory, so we have the app ask the
-// user to pick a directory instead of the file in the directory.
-// Everyone else is fine though.
-#if defined(APP_API) && defined(__APPLE__)
-  #define NAM_PICK_DIRECTORY
-#endif


### PR DESCRIPTION
In order to support navigating files via MIDI messages (when the UI might not exist) the code that manages the list of NAM or IR files in a folder is extracted to a separate class. Also the arrow keys can be used to navigate the Model/IR files.