### PR TITLE
Use clang with "-march=x86-64-v3" for building plugin

### DIFF
--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
@@ -58,7 +58,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -206,6 +206,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>$(VST3_INC_PATHS);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>%(AdditionalOptions) -march=x86-64-v3</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
Using clang with "-march=x86-64-v3" optimizations results in a significant reduction in CPU usage.

On my machine, a single standard NAM model goes from ".15c" (15% of a CPU core) to ".11c"/".12c" - so a 20-25% CPU reduction.

I'd seen a small reduction in CPU by just switching to clang, but @38github keyed me into the additional benefit with the architecture-specific optimization.

This change has two downsides:
 - it requires clang for Visual Studio to be installed to build
 - it only works on "modern" CPUs (about Intel Haswell and later - so circa 2013)

I think the performance increases are significant enough to warrant using this method to build the default Windows plugin. It may also make since to provide a "compatibility" build for older systems. 