### PR TITLE
Add resampling info message

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -558,9 +558,7 @@ void NeuralAmpModeler::_CheckSampleRateWarning()
     if (_HaveModel())
     {
       const auto pluginSampleRate = GetSampleRate();
-      const auto namSampleRateFromModel = mModel->GetExpectedSampleRate();
-      // Any model with "-1" is probably 48k
-      const auto namSampleRate = namSampleRateFromModel == -1.0 ? 48000.0 : namSampleRateFromModel;
+      const auto namSampleRate = mModel->GetEncapsulatedSampleRate();
       control->SetSampleRate(namSampleRate);
       showWarning = pluginSampleRate != namSampleRate;
     }

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -431,7 +431,7 @@ public:
   }
 };
 
-const IText _WARNING_TEXT(DEFAULT_TEXT_SIZE + 3.f, COLOR_RED, "Roboto-Regular", EAlign::Near);
+const IText _WARNING_TEXT(DEFAULT_TEXT_SIZE + 3.f, PluginColors::NAM_THEMECOLOR, "Roboto-Regular", EAlign::Near);
 
 class NAMSampleRateWarningControl : public ITextControl
 {
@@ -456,7 +456,7 @@ public:
   void SetSampleRate(const double sampleRate)
   {
     std::stringstream ss;
-    ss << "WARNING: NAM model expects sample rate " << static_cast<long>(std::round(sampleRate));
+    ss << "[INFO] Resampling to " << static_cast<long>(std::round(sampleRate)) << " Hz";
     SetStr(ss.str().c_str());
   }
 


### PR DESCRIPTION
Display in the plugin when resampling is happening.

<img width="609" alt="image" src="https://github.com/sdatkinson/NeuralAmpModelerPlugin/assets/12240186/7a0fc115-1077-4d4e-8b47-7c301b5b24e0">

_Running with my interface set to 44.1kHz._


I was on the fence about this--most plugins don't say when they're doing resampling internally. But, I think it's important to call out here because (1) it adds several ms of latency and (2) it's something that the user can affect in unexpected ways--unlike other non-open-source modelers out there, NAM lets you train models at whatever sample rate you want. So this could be very unexpected to a user (e.g. if they stumble upon a model trained at 96k by some power user).

Additionally, if someone stacks NAMs (e.g. OD into an amp) then the total added latency from two instances (over 5 ms due to resampling alone) may become noticeable and negatively impact the playing experience.

I don't want this to be mysterious. I want folks to be informed about it so that they can (if they desire) pick a sample rate that works with the model they're using that enables the plugin to avoid the need to resample and therefore not add latency.