### PR TITLE
Fix iPlug2's Lanczos resampler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "iPlug2"]
 	path = iPlug2
-	url = https://github.com/iPlug2/iPlug2
+	# url = https://github.com/iPlug2/iPlug2
+	url = https://github.com/sdatkinson/iPlug2.git
 [submodule "eigen"]
 	path = eigen
 	url = https://gitlab.com/libeigen/eigen.git


### PR DESCRIPTION
The Lanczos resampler had a bug regarding its use of `A` as well as a filter that didn't have good enough anti-aliasing properties.

This fixes both.

_I'm on my fork of iPlug2 so that I can push out a release on time. If the upstream iPlug2 agrees with my parameter setting and merges my bug fix PR, then I can follow that again._

Resolves #398
Resolves #400