### PR TITLE
Update to the latest iPlug2 with RealtimeResampler 

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -9,8 +9,7 @@
 
 #include "IPlug_include_in_plug_hdr.h"
 #include "ISender.h"
-#define M_PI 3.141592653589793238462643383279 // Needed by NonIntegerResampler.h
-#include "NonIntegerResampler.h"
+#include "RealtimeResampler.h"
 
 const int kNumPresets = 1;
 // The plugin is mono inside
@@ -189,7 +188,7 @@ private:
   bool mFinalized = true;
 
   // The resampling wrapper
-  iplug::NonIntegerResampler<NAM_SAMPLE, 1> mResampler;
+  iplug::RealtimeResampler<NAM_SAMPLE, 1, 12> mResampler;
 
   // Used to check that we don't get too large a block to process.
   int mMaxExternalBlockSize = 0;

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -304,7 +304,11 @@ public:
       else
       {
         CheckSelectedItem();
-        mMainMenu.SetChosenItemIdx(mSelectedItemIndex);
+        
+        if (!mMainMenu.HasSubMenus())
+        {
+          mMainMenu.SetChosenItemIdx(mSelectedItemIndex);
+        }
         pCaller->GetUI()->CreatePopupMenu(*this, mMainMenu, pCaller->GetRECT());
       }
     };

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -228,7 +228,7 @@ public:
 
       if (pItem)
       {
-        mSelectedIndex = mItems.Find(pItem);
+        mSelectedItemIndex = mItems.Find(pItem);
         LoadFileAtCurrentIndex();
       }
     }
@@ -240,10 +240,10 @@ public:
       const auto nItems = NItems();
       if (nItems == 0)
         return;
-      mSelectedIndex--;
+      mSelectedItemIndex--;
 
-      if (mSelectedIndex < 0)
-        mSelectedIndex = nItems - 1;
+      if (mSelectedItemIndex < 0)
+        mSelectedItemIndex = nItems - 1;
 
       LoadFileAtCurrentIndex();
     };
@@ -252,10 +252,10 @@ public:
       const auto nItems = NItems();
       if (nItems == 0)
         return;
-      mSelectedIndex++;
+      mSelectedItemIndex++;
 
-      if (mSelectedIndex >= nItems)
-        mSelectedIndex = 0;
+      if (mSelectedItemIndex >= nItems)
+        mSelectedItemIndex = 0;
 
       LoadFileAtCurrentIndex();
     };
@@ -304,7 +304,7 @@ public:
       else
       {
         CheckSelectedItem();
-        mMainMenu.SetChosenItemIdx(mSelectedIndex);
+        mMainMenu.SetChosenItemIdx(mSelectedItemIndex);
         pCaller->GetUI()->CreatePopupMenu(*this, mMainMenu, pCaller->GetRECT());
       }
     };
@@ -333,7 +333,7 @@ public:
 
   void LoadFileAtCurrentIndex()
   {
-    if (mSelectedIndex > -1 && mSelectedIndex < NItems())
+    if (mSelectedItemIndex > -1 && mSelectedItemIndex < NItems())
     {
       WDL_String fileName, path;
       GetSelectedFile(fileName);
@@ -373,7 +373,7 @@ public:
   }
 
 private:
-  void SelectFirstFile() { mSelectedIndex = mFiles.GetSize() ? 0 : -1; }
+  void SelectFirstFile() { mSelectedItemIndex = mFiles.GetSize() ? 0 : -1; }
 
   void GetSelectedFileDirectory(WDL_String& path)
   {


### PR DESCRIPTION
This should switch to the (rebased) utf8-fixes branch, which includes the fixed RealtimeResampler class. It renames the resampler class and update the file browser control due to a changed member variable and prevent a crash when folders with subfolders are added. Changes to the RealtimeResampler class also include fixes todo with the buffer memory being zeroed and the buffer always being fixed at DEFAULT_BLOCK_SIZE instead of set dynamically. 
