### PR TITLE
[CHORE] Update workflow

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -68,7 +68,7 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: |
         ARCHIVE_NAME=`python3 iPlug2/Scripts/get_archive_name.py ${{env.PROJECT_NAME}} mac full`
-        echo "::set-output name=archive_name::$ARCHIVE_NAME"
+        echo "archive_name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Build macOS
@@ -116,7 +116,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         ARCHIVE_NAME=`python.exe iPlug2/Scripts/get_archive_name.py ${{env.PROJECT_NAME}} win full`
-        echo "::set-output name=archive_name::$ARCHIVE_NAME"
+        echo "archive_name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Build Windows


### PR DESCRIPTION
Update how outputs are set following deprecation info at 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/