### PR TITLE
remove previous build log

### DIFF
--- a/NeuralAmpModeler/scripts/makedist-win.bat
+++ b/NeuralAmpModeler/scripts/makedist-win.bat
@@ -48,6 +48,8 @@ copy /b *.cpp+,,
 echo ------------------------------------------------------------------
 echo Building ...
 
+if exist "build-win.log" (del build-win.log)
+
 if exist "%ProgramFiles(x86)%" (goto 64-Bit) else (goto 32-Bit)
 
 if not defined DevEnvDir (


### PR DESCRIPTION
Removing previous build log (windows builds) prevents you seeing a bunch of errors [from the previous build] that you already fixed.

Just added

    if exist "build-win.log" (del build-win.log)
    
No big deal.