### PR TITLE
Drag and drop capabilities for models and IRs

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -250,6 +250,9 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
       helpSVG));
 
     pGraphics->AttachControl(new NAMAboutBoxControl(b, backgroundBitmap, style), kCtrlTagAboutBox)->Hide(true);
+   
+    // Implements drag and drop capabilities for plugin
+    pGraphics->AttachControl(new NAMDragDropControl(mainArea, loadModelCompletionHandler)); 
 
     pGraphics->ForAllControlsFunc([](IControl* pControl) {
       pControl->SetMouseEventsWhenDisabled(true);

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath> // std::round
+#include <functional> // std::function
 #include <sstream> // std::stringstream
 #include "IControls.h"
 
@@ -557,4 +558,37 @@ private:
   IVStyle mStyle;
   int mAnimationTime = 200;
   bool mWillHide = false;
+};
+
+class NAMDragDropControl : public IControl
+{
+public:
+    NAMDragDropControl(const IRECT& bounds, 
+                       std::function<void(const WDL_String&, const WDL_String&)> loadModelCompletionHandler)
+        : IControl(bounds), loadModel(loadModelCompletionHandler)
+    {
+      mIgnoreMouse = true;
+    }
+
+    void Draw(IGraphics& g) override
+    {}
+
+    void OnDrop(const char* str) override
+    {
+        // Handle the dropped data
+        if (str)
+        {
+          std::cout << "Dropped data: " << str << std::endl;
+          
+          WDL_String fileName, directory;
+          fileName.Set(str);
+          directory.Set(str);
+          directory.remove_filepart(true);
+
+          loadModel(fileName, directory);
+        }
+    }
+
+private:
+  std::function<void(const WDL_String&, const WDL_String&)> loadModel;
 };


### PR DESCRIPTION
As suggested in #445.

Currently the NAMDragDropControl class does not allow passthrough of clicks, therefore only one of: allowing drag and drop or using the plugin as normal is possible. I could add the onDrop on the individual NAMFileBrowserControl instances, but it wouldn't be as easy to use, in my opinion.

What's missing:
- [ ] Find a way to allow NAMDragDropControl to passthrough mousevents to controls below, or place it below and allow others to pass through onDrop.
- [ ] Add checks for valid file types, add support for IRs (couple lines of code).
- [ ] Check if file browser works as intended after dropping in a model.
- [ ] Add overlay to indicate to user that the plugin supports drag and drop, when holding a file over the plugin.

The first point is the one I'm mostly stuck in, everything else should be easy to implement. Any ideas?