### PR TITLE
Upgrade core to v0.2.0

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -6,6 +6,7 @@
 
 #include "Colors.h"
 #include "NeuralAmpModelerCore/NAM/activations.h"
+#include "NeuralAmpModelerCore/NAM/get_dsp.h"
 // clang-format off
 // These includes need to happen in this order or else the latter won't know
 // a bunch of stuff.

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj
@@ -530,6 +530,7 @@
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\get_dsp.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj.filters
@@ -313,6 +313,9 @@
       <Filter>dsp\ResamplingContainer\Dependencies\WDL</Filter>
     </ClInclude>
     <ClInclude Include="..\ToneStack.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\get_dsp.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="resources">

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
@@ -337,6 +337,7 @@
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\get_dsp.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj.filters
@@ -361,6 +361,9 @@
       <Filter>dsp\ResamplingContainer\Dependencies\WDL</Filter>
     </ClInclude>
     <ClInclude Include="..\ToneStack.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\get_dsp.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="resources">

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-iOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-iOS.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		AA7C860E2B43A42F00B5FB3A /* ptrlist.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7C86092B43A42E00B5FB3A /* ptrlist.h */; };
 		AA7C860F2B43A42F00B5FB3A /* heapbuf.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7C860A2B43A42E00B5FB3A /* heapbuf.h */; };
 		AA8CA7772A452EF500F5BEF0 /* resample.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8CA7752A452EF500F5BEF0 /* resample.cpp */; };
+		AAB7BBB92CC4B8D6000B8B6E /* get_dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB7BBB82CC4B8D6000B8B6E /* get_dsp.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -353,6 +354,7 @@
 		AA7C86092B43A42E00B5FB3A /* ptrlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ptrlist.h; sourceTree = "<group>"; };
 		AA7C860A2B43A42E00B5FB3A /* heapbuf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = heapbuf.h; sourceTree = "<group>"; };
 		AA8CA7752A452EF500F5BEF0 /* resample.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resample.cpp; sourceTree = "<group>"; };
+		AAB7BBB82CC4B8D6000B8B6E /* get_dsp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = get_dsp.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -661,6 +663,7 @@
 				4FBDC94229FFF143004FF203 /* convnet.h */,
 				4FBDC94129FFF143004FF203 /* dsp.cpp */,
 				4FBDC94829FFF143004FF203 /* dsp.h */,
+				AAB7BBB82CC4B8D6000B8B6E /* get_dsp.h */,
 				4FBDC94C29FFF143004FF203 /* get_dsp.cpp */,
 				4FBDC94629FFF143004FF203 /* lstm.cpp */,
 				4FBDC94329FFF143004FF203 /* lstm.h */,
@@ -843,6 +846,7 @@
 				4FBDC95529FFF143004FF203 /* ImpulseResponse.h in Headers */,
 				4FBDC95029FFF143004FF203 /* NoiseGate.h in Headers */,
 				4FBDC96129FFF143004FF203 /* dsp.h in Headers */,
+				AAB7BBB92CC4B8D6000B8B6E /* get_dsp.h in Headers */,
 				4FBDC96029FFF143004FF203 /* util.h in Headers */,
 				4FBDC94F29FFF143004FF203 /* wav.h in Headers */,
 			);

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		AA7C86002B439AC000B5FB3A /* ptrlist.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7C85F72B439AC000B5FB3A /* ptrlist.h */; };
 		AA7C86012B439AC000B5FB3A /* heapbuf.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7C85F82B439AC000B5FB3A /* heapbuf.h */; };
 		AA7C86022B439AC000B5FB3A /* heapbuf.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7C85F82B439AC000B5FB3A /* heapbuf.h */; };
+		AAB7BBB72CC4B8C6000B8B6E /* get_dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB7BBB62CC4B8C6000B8B6E /* get_dsp.h */; };
 		B885CBC52304AE7300D73128 /* IPlugProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F8F61A8202807B9003F2573 /* IPlugProcessor.cpp */; };
 		B8E22A0C220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */; };
 		B8E22A0D220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */; };
@@ -1031,6 +1032,7 @@
 		AA7C85F62B439AC000B5FB3A /* wdltypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wdltypes.h; sourceTree = "<group>"; };
 		AA7C85F72B439AC000B5FB3A /* ptrlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ptrlist.h; sourceTree = "<group>"; };
 		AA7C85F82B439AC000B5FB3A /* heapbuf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = heapbuf.h; sourceTree = "<group>"; };
+		AAB7BBB62CC4B8C6000B8B6E /* get_dsp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = get_dsp.h; sourceTree = "<group>"; };
 		B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.cpp.cpp; name = IPlugVST3_ProcessorBase.cpp; path = ../../iPlug2/IPlug/VST3/IPlugVST3_ProcessorBase.cpp; sourceTree = "<group>"; tabWidth = 2; };
 		B8E22A0B220268C4007CBF4C /* IPlugVST3_ProcessorBase.h */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.h; name = IPlugVST3_ProcessorBase.h; path = ../../iPlug2/IPlug/VST3/IPlugVST3_ProcessorBase.h; sourceTree = "<group>"; tabWidth = 2; };
 		B8EA6B932203868500D23A86 /* IPlugVST3_Common.h */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.h; name = IPlugVST3_Common.h; path = ../../iPlug2/IPlug/VST3/IPlugVST3_Common.h; sourceTree = "<group>"; tabWidth = 2; };
@@ -1295,6 +1297,7 @@
 				4F2FB1482A0047420027AB66 /* dsp.cpp */,
 				4F2FB14F2A0047420027AB66 /* dsp.h */,
 				4F2FB1532A0047420027AB66 /* get_dsp.cpp */,
+				AAB7BBB62CC4B8C6000B8B6E /* get_dsp.h */,
 				4F2FB14D2A0047420027AB66 /* lstm.cpp */,
 				4F2FB14A2A0047420027AB66 /* lstm.h */,
 				4F2FB1462A0047420027AB66 /* util.cpp */,
@@ -2018,6 +2021,7 @@
 				4F78BE1222E73DD900AD537E /* NeuralAmpModelerAU.h in Headers */,
 				4F2FB1542A0047420027AB66 /* Resample.h in Headers */,
 				4F2FB15E2A0047420027AB66 /* wav.h in Headers */,
+				AAB7BBB72CC4B8C6000B8B6E /* get_dsp.h in Headers */,
 				4F2FB1902A0047430027AB66 /* version.h in Headers */,
 				AA7C86002B439AC000B5FB3A /* ptrlist.h in Headers */,
 				4F4856852773C3B5005BCF8E /* IPlugAUViewController.h in Headers */,

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
@@ -346,6 +346,7 @@
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\activations.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\convnet.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\get_dsp.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\lstm.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\util.h" />
     <ClInclude Include="..\NeuralAmpModelerCore\NAM\version.h" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj.filters
@@ -460,6 +460,9 @@
       <Filter>dsp\ResamplingContainer\Dependencies\WDL</Filter>
     </ClInclude>
     <ClInclude Include="..\ToneStack.h" />
+    <ClInclude Include="..\NeuralAmpModelerCore\NAM\get_dsp.h">
+      <Filter>NAM</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="resources">


### PR DESCRIPTION
## Description
Update [NeuralAmpModelerCore](https://github.com/sdatkinson/NeuralAmpModelerCore) to v0.2.0.
Resolves #514.

## PR Checklist
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [x] Windows
  - [x] macOS
- [N] Does your PR add, remove, or rename any plugin parameters? _No._
  - [N/A] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
  
