### PR TITLE
Don't `SetLatency()` when it won't change the latency.

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -366,7 +366,11 @@ void NeuralAmpModeler::OnReset()
   // If there is a model or IR loaded, they need to be checked for resampling.
   _ResetModelAndIR(sampleRate, GetBlockSize());
   mToneStack->Reset(sampleRate, maxBlockSize);
-  _UpdateLatency();
+  if (sampleRate != mLastSampleRate)
+  {
+    _UpdateLatency();
+  }
+  mLastSampleRate = sampleRate;
 }
 
 void NeuralAmpModeler::OnIdle()

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -366,11 +366,7 @@ void NeuralAmpModeler::OnReset()
   // If there is a model or IR loaded, they need to be checked for resampling.
   _ResetModelAndIR(sampleRate, GetBlockSize());
   mToneStack->Reset(sampleRate, maxBlockSize);
-  if (sampleRate != mLastSampleRate)
-  {
-    _UpdateLatency();
-  }
-  mLastSampleRate = sampleRate;
+  _UpdateLatency();
 }
 
 void NeuralAmpModeler::OnIdle()
@@ -894,7 +890,12 @@ void NeuralAmpModeler::_UpdateLatency()
     latency += mModel->GetLatency();
   }
   // Other things that add latency here...
-  SetLatency(latency);
+
+  // Feels weird to have to do this.
+  if (GetLatency() != latency)
+  {
+    SetLatency(latency);
+  }
 }
 
 void NeuralAmpModeler::_UpdateMeters(sample** inputPointer, sample** outputPointer, const size_t nFrames,

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -245,9 +245,6 @@ private:
 
   // Member data
 
-  // Updated every time we OnReset()
-  double mLastSampleRate = -1.0;
-
   // Input arrays to NAM
   std::vector<std::vector<iplug::sample>> mInputArray;
   // Output from NAM

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -245,6 +245,9 @@ private:
 
   // Member data
 
+  // Updated every time we OnReset()
+  double mLastSampleRate = -1.0;
+
   // Input arrays to NAM
   std::vector<std::vector<iplug::sample>> mInputArray;
   // Output from NAM


### PR DESCRIPTION
## Description

During `_UpdateLatency()`, Only `SetLatency(latency)` when `latency != GetLatency()`.

It feels weird to have to do this but it works.

Resolves #507

## PR Checklist
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [x] Windows
  - [x] macOS
- [N] Does your PR add, remove, or rename any plugin parameters?
  - [N/A] If yes, then have you ensured that older versions of the plug-in load correctly?