### PR TITLE
Refactor settings page with `IContainerBaseWithNamedChildren`

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -246,11 +246,11 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     pGraphics->AttachControl(new NAMCircleButtonControl(
       settingsButtonArea,
       [pGraphics](IControl* pCaller) {
-        pGraphics->GetControlWithTag(kCtrlTagSettingsBox)->As<NAMAboutBoxControl>()->HideAnimated(false);
+        pGraphics->GetControlWithTag(kCtrlTagSettingsBox)->As<NAMSettingsPageControl>()->HideAnimated(false);
       },
       gearSVG));
 
-    pGraphics->AttachControl(new NAMAboutBoxControl(b, backgroundBitmap, style), kCtrlTagSettingsBox)->Hide(true);
+    pGraphics->AttachControl(new NAMSettingsPageControl(b, backgroundBitmap, style), kCtrlTagSettingsBox)->Hide(true);
 
     pGraphics->ForAllControlsFunc([](IControl* pControl) {
       pControl->SetMouseEventsWhenDisabled(true);


### PR DESCRIPTION
## Description
Add helper class that extends `iplug::igraphics::IContainerBase` to enable working with child controls by name instead of by index that's assigned when they're added.

## PR Checklist
- [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [x] macOS
- [N] Does your PR add, remove, or rename any plugin parameters?
  - [N/A] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
  
