### PR TITLE
[FEATURE] Display model sample rate on settings page

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -164,7 +164,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     const auto outputMeterArea = contentArea.GetFromRight(30).GetHShifted(20).GetMidVPadded(100).GetVShifted(-25);
 
     // Misc Areas
-    const auto settingsButtonArea = mainArea.GetFromTRHC(50, 50).GetCentredInside(20, 20);
+    const auto settingsButtonArea = CornerButtonArea(b);
 
     // Model loader button
     auto loadModelCompletionHandler = [&](const WDL_String& fileName, const WDL_String& path) {
@@ -250,7 +250,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
       },
       gearSVG));
 
-    pGraphics->AttachControl(new NAMSettingsPageControl(b, backgroundBitmap, style), kCtrlTagSettingsBox)->Hide(true);
+    pGraphics->AttachControl(new NAMSettingsPageControl(b, backgroundBitmap, crossSVG, style), kCtrlTagSettingsBox)
+      ->Hide(true);
 
     pGraphics->ForAllControlsFunc([](IControl* pControl) {
       pControl->SetMouseEventsWhenDisabled(true);

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -246,11 +246,11 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     pGraphics->AttachControl(new NAMCircleButtonControl(
       settingsButtonArea,
       [pGraphics](IControl* pCaller) {
-        pGraphics->GetControlWithTag(kCtrlTagSettingsBox)->As<NAMAboutBoxControl>()->HideAnimated(false);
+        pGraphics->GetControlWithTag(kCtrlTagSettingsBox)->As<NAMSettingsPageControl>()->HideAnimated(false);
       },
       gearSVG));
 
-    pGraphics->AttachControl(new NAMAboutBoxControl(b, backgroundBitmap, style), kCtrlTagSettingsBox)->Hide(true);
+    pGraphics->AttachControl(new NAMSettingsPageControl(b, backgroundBitmap, style), kCtrlTagSettingsBox)->Hide(true);
 
     pGraphics->ForAllControlsFunc([](IControl* pControl) {
       pControl->SetMouseEventsWhenDisabled(true);

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -377,9 +377,23 @@ void NeuralAmpModeler::OnIdle()
   if (mNewModelLoadedInDSP)
   {
     if (auto* pGraphics = GetUI())
+    {
       pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(!mModel->HasLoudness());
-
-    mNewModelLoadedInDSP = false;
+      ModelInfo modelInfo;
+      modelInfo.sampleRate = mModel->GetEncapsulatedSampleRate();
+      modelInfo.knownSampleRate = true;
+      static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->SetModelInfo(modelInfo);
+      mNewModelLoadedInDSP = false;
+    }
+  }
+  if (mModelCleared)
+  {
+    if (auto* pGraphics = GetUI())
+    {
+      pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(false);
+      static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->ClearModelInfo();
+      mModelCleared = false;
+    }
   }
 }
 
@@ -534,6 +548,7 @@ void NeuralAmpModeler::_ApplyDSPStaging()
     mModel = nullptr;
     mNAMPath.Set("");
     mShouldRemoveModel = false;
+    mModelCleared = true;
     _UpdateLatency();
   }
   if (mShouldRemoveIR)

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -268,6 +268,7 @@ private:
   std::atomic<bool> mShouldRemoveIR = false;
 
   std::atomic<bool> mNewModelLoadedInDSP = false;
+  std::atomic<bool> mModelCleared = false;
 
   // Tone stack modules
   std::unique_ptr<dsp::tone_stack::AbstractToneStack> mToneStack;

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -10,6 +10,14 @@
 using namespace iplug;
 using namespace igraphics;
 
+// Where the corner button on the plugin (settings, close settings) goes
+// :param rect: Rect for the whole plugin's UI
+IRECT CornerButtonArea(const IRECT& rect)
+{
+  const auto mainArea = rect.GetPadded(-20);
+  return mainArea.GetFromTRHC(50, 50).GetCentredInside(20, 20);
+};
+
 class NAMSquareButtonControl : public ISVGButtonControl
 {
 public:
@@ -527,11 +535,12 @@ private:
 class NAMSettingsPageControl : public IContainerBaseWithNamedChildren
 {
 public:
-  NAMSettingsPageControl(const IRECT& bounds, const IBitmap& bitmap, const IVStyle& style)
+  NAMSettingsPageControl(const IRECT& bounds, const IBitmap& bitmap, ISVG closeSVG, const IVStyle& style)
   : IContainerBaseWithNamedChildren(bounds)
   , mAnimationTime(0)
   , mBitmap(bitmap)
   , mStyle(style)
+  , mCloseSVG(closeSVG)
   {
     mIgnoreMouse = false;
   }
@@ -553,8 +562,6 @@ public:
 
     return false;
   }
-
-  void OnMouseDown(float x, float y, const IMouseMod& mod) override { HideAnimated(true); }
 
   void HideAnimated(bool hide)
   {
@@ -631,8 +638,13 @@ public:
     //
     //    }, mStyle, IVColorSwatchControl::ECellLayout::kHorizontal, {kFG}, {""}));
 
-
     AddNamedChildControl(new ModelInfoControl(GetRECT().GetFromBottom(100.0f), style), mControlNames.modelInfo);
+
+    auto closeAction = [&](IControl* pCaller) {
+      static_cast<NAMSettingsPageControl*>(pCaller->GetParent())->HideAnimated(true);
+    };
+    AddNamedChildControl(
+      new NAMSquareButtonControl(CornerButtonArea(GetRECT()), closeAction, mCloseSVG), mControlNames.close);
 
     OnResize();
   }
@@ -667,6 +679,7 @@ public:
 private:
   IBitmap mBitmap;
   IVStyle mStyle;
+  ISVG mCloseSVG;
   int mAnimationTime = 200;
   bool mWillHide = false;
 
@@ -677,6 +690,7 @@ private:
     const std::string bitmap = "bitmap";
     const std::string byAuthor = "by author";
     const std::string buildInfo = "build info";
+    const std::string close = "close";
     const std::string development = "development";
     const std::string title = "title";
     const std::string website = "website";

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -529,7 +529,7 @@ private:
     const std::string sampleRate = "sampleRate";
   } mControlNames;
   // Do I have info?
-  bool mHasInfo = true;
+  bool mHasInfo = false;
 };
 
 class NAMSettingsPageControl : public IContainerBaseWithNamedChildren
@@ -638,7 +638,9 @@ public:
     //
     //    }, mStyle, IVColorSwatchControl::ECellLayout::kHorizontal, {kFG}, {""}));
 
-    AddNamedChildControl(new ModelInfoControl(GetRECT().GetFromBottom(100.0f), style), mControlNames.modelInfo);
+    AddNamedChildControl(new ModelInfoControl(GetRECT().GetPadded(-20.0f).GetFromBottom(75.0f).GetFromTop(30.0f),
+                                              style.WithValueText(style.valueText.WithAlign(EAlign::Near))),
+                         mControlNames.modelInfo);
 
     auto closeAction = [&](IControl* pCaller) {
       static_cast<NAMSettingsPageControl*>(pCaller->GetParent())->HideAnimated(true);

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -495,6 +495,9 @@ public:
     AddNamedChildControl(new IVLabelControl(GetRECT().GetGridCell(1, 0, 2, 1), "", mStyle), mControlNames.sampleRate);
   };
 
+  // Click through me
+  void OnMouseDown(float x, float y, const IMouseMod& mod) override { GetParent()->OnMouseDown(x, y, mod); }
+
   void SetModelInfo(const ModelInfo& modelInfo)
   {
     std::stringstream ss;

--- a/NeuralAmpModeler/ToneStack.h
+++ b/NeuralAmpModeler/ToneStack.h
@@ -43,7 +43,7 @@ public:
   DSP_SAMPLE** Process(DSP_SAMPLE** inputs, const int numChannels, const int numFrames);
   virtual void Reset(const double sampleRate, const int maxBlockSize) override;
   // :param val: Assumed to be between 0 and 10, 5 is "noon"
-  void SetParam(const std::string name, const double val);
+  virtual void SetParam(const std::string name, const double val) override;
 
 
 protected:


### PR DESCRIPTION
## Description
Show model information on the settings page, if one is loaded:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/2b769ed5-4ff9-4a42-9d04-70f2ae94c774">

If not, show nothing:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/709a25eb-6c7a-4ab7-a959-0a178500e3ce">

Resolves #501

## PR Checklist
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [x] macOS
- [N] Does your PR add, remove, or rename any plugin parameters?
  - [N/A] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
  
