### PR TITLE
[BUGFIX] Show model info after re-opening UI

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -387,20 +387,7 @@ void NeuralAmpModeler::OnIdle()
     if (auto* pGraphics = GetUI())
     {
       pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(!mModel->HasLoudness());
-      ModelInfo modelInfo;
-      modelInfo.sampleRate.known = true;
-      modelInfo.sampleRate.value = mModel->GetEncapsulatedSampleRate();
-      modelInfo.inputCalibrationLevel.known = mModel->HasInputLevel();
-      modelInfo.inputCalibrationLevel.value = mModel->HasInputLevel() ? mModel->GetInputLevel() : 0.0;
-      modelInfo.outputCalibrationLevel.known = mModel->HasOutputLevel();
-      modelInfo.outputCalibrationLevel.value = mModel->HasOutputLevel() ? mModel->GetOutputLevel() : 0.0;
-
-      static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->SetModelInfo(modelInfo);
-
-      const bool disableInputCalibrationControls = !mModel->HasInputLevel();
-      pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetDisabled(disableInputCalibrationControls);
-      pGraphics->GetControlWithTag(kCtrlTagInputCalibrationLevel)->SetDisabled(disableInputCalibrationControls);
-
+      _UpdateControlsFromModel();
       mNewModelLoadedInDSP = false;
     }
   }
@@ -479,12 +466,7 @@ void NeuralAmpModeler::OnUIOpen()
 
   if (mModel != nullptr)
   {
-    auto* pGraphics = GetUI();
-    assert(pGraphics != nullptr);
-    pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(!mModel->HasLoudness());
-    const bool disableInputCalibrationControls = !mModel->HasInputLevel();
-    pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetDisabled(disableInputCalibrationControls);
-    pGraphics->GetControlWithTag(kCtrlTagInputCalibrationLevel)->SetDisabled(disableInputCalibrationControls);
+    _UpdateControlsFromModel();
   }
 }
 
@@ -937,6 +919,31 @@ int NeuralAmpModeler::_UnserializeStateLegacy_0_7_9(const IByteChunk& chunk, int
   };
   pos = unserialize(chunk, pos);
   return pos;
+}
+
+void NeuralAmpModeler::_UpdateControlsFromModel()
+{
+  if (mModel == nullptr)
+  {
+    return;
+  }
+  if (auto* pGraphics = GetUI())
+  {
+    ModelInfo modelInfo;
+    modelInfo.sampleRate.known = true;
+    modelInfo.sampleRate.value = mModel->GetEncapsulatedSampleRate();
+    modelInfo.inputCalibrationLevel.known = mModel->HasInputLevel();
+    modelInfo.inputCalibrationLevel.value = mModel->HasInputLevel() ? mModel->GetInputLevel() : 0.0;
+    modelInfo.outputCalibrationLevel.known = mModel->HasOutputLevel();
+    modelInfo.outputCalibrationLevel.value = mModel->HasOutputLevel() ? mModel->GetOutputLevel() : 0.0;
+
+    static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->SetModelInfo(modelInfo);
+
+    const bool disableInputCalibrationControls = !mModel->HasInputLevel();
+    pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(!mModel->HasLoudness());
+    pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetDisabled(disableInputCalibrationControls);
+    pGraphics->GetControlWithTag(kCtrlTagInputCalibrationLevel)->SetDisabled(disableInputCalibrationControls);
+  }
 }
 
 void NeuralAmpModeler::_UpdateLatency()

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -251,6 +251,9 @@ private:
   int _UnserializeStateLegacy_0_7_9(const iplug::IByteChunk& chunk, int startPos);
   // And other legacy unsrializations if/as needed...
 
+  // Update all controls that depend on a model
+  void _UpdateControlsFromModel();
+
   // Make sure that the latency is reported correctly.
   void _UpdateLatency();
 


### PR DESCRIPTION
## Description
Resolves #524

## PR Checklist
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [x] macOS
- [N] Does your PR add, remove, or rename any plugin parameters?
  - [N/A] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
  
