### PR TITLE
[FEATURE] Output calibration

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -380,8 +380,6 @@ void NeuralAmpModeler::OnIdle()
   {
     if (auto* pGraphics = GetUI())
     {
-      // FIXME -- need to disable only the "normalized" model
-      // pGraphics->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(!mModel->HasLoudness());
       _UpdateControlsFromModel();
       mNewModelLoadedInDSP = false;
     }
@@ -953,10 +951,13 @@ void NeuralAmpModeler::_UpdateControlsFromModel()
     static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->SetModelInfo(modelInfo);
 
     const bool disableInputCalibrationControls = !mModel->HasInputLevel();
-    // FIXME -- need to disable only the "normalized" model
-    //    pGraphics->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(!mModel->HasLoudness());
     pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetDisabled(disableInputCalibrationControls);
     pGraphics->GetControlWithTag(kCtrlTagInputCalibrationLevel)->SetDisabled(disableInputCalibrationControls);
+    {
+      auto* c = static_cast<OutputModeControl*>(pGraphics->GetControlWithTag(kCtrlTagOutputMode));
+      c->SetNormalizedDisable(!mModel->HasLoudness());
+      c->SetCalibratedDisable(!mModel->HasOutputLevel());
+    }
   }
 }
 

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -79,10 +79,9 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
   GetParam(kNoiseGateThreshold)->InitGain("Threshold", -80.0, -100.0, 0.0, 0.1);
   GetParam(kNoiseGateActive)->InitBool("NoiseGateActive", true);
   GetParam(kEQActive)->InitBool("ToneStack", true);
-  GetParam(kOutNorm)->InitBool("OutNorm", true);
+  GetParam(kOutputMode)->InitEnum("OutputMode", 1, {"Raw", "Normalized", "Calibrated"}); // TODO DRY w/ control
   GetParam(kIRToggle)->InitBool("IRToggle", true);
   GetParam(kCalibrateInput)->InitBool("CalibrateInput", false);
-  // TODO Double, label "dBu"
   GetParam(kInputCalibrationLevel)->InitDouble("InputCalibrationLevel", 12.5, -30.0, 30.0, 0.1, "dBu");
 
   mNoiseGateTrigger.AddListener(&mNoiseGateGain);
@@ -227,8 +226,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     pGraphics->AttachControl(
       new NAMSwitchControl(ngToggleArea, kNoiseGateActive, "Noise Gate", style, switchHandleBitmap));
     pGraphics->AttachControl(new NAMSwitchControl(eqToggleArea, kEQActive, "EQ", style, switchHandleBitmap));
-    pGraphics->AttachControl(
-      new NAMSwitchControl(outNormToggleArea, kOutNorm, "Normalize", style, switchHandleBitmap), kCtrlTagOutNorm);
+    // pGraphics->AttachControl(
+    //   new NAMSwitchControl(outNormToggleArea, kOutNorm, "Normalize", style, switchHandleBitmap), kCtrlTagOutputMode);
 
     // The knobs
     pGraphics->AttachControl(new NAMKnobControl(inputKnobArea, kInputLevel, "", style, knobBackgroundBitmap));
@@ -312,20 +311,13 @@ void NeuralAmpModeler::ProcessBlock(iplug::sample** inputs, iplug::sample** outp
 
   if (mModel != nullptr)
   {
-    // TODO multi-channel processing; Issue
-    // Make sure it's multi-threaded or else this won't perform well!
     mModel->process(triggerOutput[0], mOutputPointers[0], nFrames);
-    // Normalize loudness
-    if (GetParam(kOutNorm)->Value())
-    {
-      _NormalizeModelOutput(mOutputPointers, numChannelsInternal, numFrames);
-    }
   }
   else
   {
     _FallbackDSP(triggerOutput, mOutputPointers, numChannelsInternal, numFrames);
   }
-  // Apply the noise gate
+  // Apply the noise gate after the NAM
   sample** gateGainOutput =
     noiseGateActive ? mNoiseGateGain.Process(mOutputPointers, numChannelsInternal, numFrames) : mOutputPointers;
 
@@ -386,7 +378,8 @@ void NeuralAmpModeler::OnIdle()
   {
     if (auto* pGraphics = GetUI())
     {
-      pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(!mModel->HasLoudness());
+      // FIXME -- need to disable only the "normalized" model
+      // pGraphics->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(!mModel->HasLoudness());
       _UpdateControlsFromModel();
       mNewModelLoadedInDSP = false;
     }
@@ -395,7 +388,8 @@ void NeuralAmpModeler::OnIdle()
   {
     if (auto* pGraphics = GetUI())
     {
-      pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(false);
+      // FIXME -- need to disable only the "normalized" model
+      // pGraphics->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(false);
       static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->ClearModelInfo();
       mModelCleared = false;
     }
@@ -478,6 +472,9 @@ void NeuralAmpModeler::OnParamChange(int paramIdx)
     case kCalibrateInput:
     case kInputCalibrationLevel:
     case kInputLevel: _SetInputGain(); break;
+    // Changes to the output gain
+    case kOutputLevel:
+    case kOutputMode: _SetOutputGain(); break;
     // Tone stack:
     case kToneBass: mToneStack->SetParam("bass", GetParam(paramIdx)->Value()); break;
     case kToneMid: mToneStack->SetParam("middle", GetParam(paramIdx)->Value()); break;
@@ -563,6 +560,7 @@ void NeuralAmpModeler::_ApplyDSPStaging()
     mModelCleared = true;
     _UpdateLatency();
     _SetInputGain();
+    _SetOutputGain();
   }
   if (mShouldRemoveIR)
   {
@@ -573,12 +571,12 @@ void NeuralAmpModeler::_ApplyDSPStaging()
   // Move things from staged to live
   if (mStagedModel != nullptr)
   {
-    // Move from staged to active DSP
     mModel = std::move(mStagedModel);
     mStagedModel = nullptr;
     mNewModelLoadedInDSP = true;
     _UpdateLatency();
     _SetInputGain();
+    _SetOutputGain();
   }
   if (mStagedIR != nullptr)
   {
@@ -611,24 +609,6 @@ void NeuralAmpModeler::_FallbackDSP(iplug::sample** inputs, iplug::sample** outp
   for (auto c = 0; c < numChannels; c++)
     for (auto s = 0; s < numFrames; s++)
       mOutputArray[c][s] = mInputArray[c][s];
-}
-
-void NeuralAmpModeler::_NormalizeModelOutput(iplug::sample** buffer, const size_t numChannels, const size_t numFrames)
-{
-  if (!mModel)
-    return;
-  if (!mModel->HasLoudness())
-    return;
-  const double loudness = mModel->GetLoudness();
-  const double targetLoudness = -18.0;
-  const double gain = pow(10.0, (targetLoudness - loudness) / 20.0);
-  for (size_t c = 0; c < numChannels; c++)
-  {
-    for (size_t f = 0; f < numFrames; f++)
-    {
-      buffer[c][f] *= gain;
-    }
-  }
 }
 
 void NeuralAmpModeler::_ResetModelAndIR(const double sampleRate, const int maxBlockSize)
@@ -673,6 +653,37 @@ void NeuralAmpModeler::_SetInputGain()
     inputGainDB += GetParam(kInputCalibrationLevel)->Value() - mModel->GetInputLevel();
   }
   mInputGain = DBToAmp(inputGainDB);
+}
+
+void NeuralAmpModeler::_SetOutputGain()
+{
+  double gainDB = GetParam(kOutputLevel)->Value();
+  if (mModel != nullptr)
+  {
+    const int outputMode = GetParam(kOutputMode)->Int();
+    switch (outputMode)
+    {
+      case 1: // Normalized
+        if (mModel->HasLoudness())
+        {
+          const double loudness = mModel->GetLoudness();
+          const double targetLoudness = -18.0;
+          gainDB += (targetLoudness - loudness);
+        }
+        break;
+      case 2: // Calibrated
+        if (mModel->HasOutputLevel())
+        {
+          const double inputLevel = GetParam(kInputCalibrationLevel)->Value();
+          const double outputLevel = mModel->GetOutputLevel();
+          gainDB += (outputLevel - inputLevel);
+        }
+        break;
+      case 0: // Raw
+      default: break;
+    }
+  }
+  mOutputGain = DBToAmp(gainDB);
 }
 
 std::string NeuralAmpModeler::_StageModel(const WDL_String& modelPath)
@@ -830,7 +841,7 @@ void NeuralAmpModeler::_ProcessInput(iplug::sample** inputs, const size_t nFrame
 void NeuralAmpModeler::_ProcessOutput(iplug::sample** inputs, iplug::sample** outputs, const size_t nFrames,
                                       const size_t nChansIn, const size_t nChansOut)
 {
-  const double gain = pow(10.0, GetParam(kOutputLevel)->Value() / 20.0);
+  const double gain = mOutputGain;
   // Assume _PrepareBuffers() was already called
   if (nChansIn != 1)
     throw std::runtime_error("Plugin is supposed to process in mono.");
@@ -940,7 +951,8 @@ void NeuralAmpModeler::_UpdateControlsFromModel()
     static_cast<NAMSettingsPageControl*>(pGraphics->GetControlWithTag(kCtrlTagSettingsBox))->SetModelInfo(modelInfo);
 
     const bool disableInputCalibrationControls = !mModel->HasInputLevel();
-    pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(!mModel->HasLoudness());
+    // FIXME -- need to disable only the "normalized" model
+    //    pGraphics->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(!mModel->HasLoudness());
     pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetDisabled(disableInputCalibrationControls);
     pGraphics->GetControlWithTag(kCtrlTagInputCalibrationLevel)->SetDisabled(disableInputCalibrationControls);
   }

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -54,6 +54,8 @@ const IVStyle style =
 const IVStyle titleStyle =
   DEFAULT_STYLE.WithValueText(IText(30, COLOR_WHITE, "Michroma-Regular")).WithDrawFrame(false).WithShadowOffset(2.f);
 
+const IVStyle radioButtonStyle = style.WithColor(EVColor::kON, PluginColors::NAM_THEMEFONTCOLOR);
+
 EMsgBoxResult _ShowMessageBox(iplug::igraphics::IGraphics* pGraphics, const char* str, const char* caption,
                               EMsgBoxType type)
 {
@@ -226,8 +228,6 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     pGraphics->AttachControl(
       new NAMSwitchControl(ngToggleArea, kNoiseGateActive, "Noise Gate", style, switchHandleBitmap));
     pGraphics->AttachControl(new NAMSwitchControl(eqToggleArea, kEQActive, "EQ", style, switchHandleBitmap));
-    // pGraphics->AttachControl(
-    //   new NAMSwitchControl(outNormToggleArea, kOutNorm, "Normalize", style, switchHandleBitmap), kCtrlTagOutputMode);
 
     // The knobs
     pGraphics->AttachControl(new NAMKnobControl(inputKnobArea, kInputLevel, "", style, knobBackgroundBitmap));
@@ -253,8 +253,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
       gearSVG));
 
     pGraphics
-      ->AttachControl(new NAMSettingsPageControl(
-                        b, backgroundBitmap, inputLevelBackgroundBitmap, switchHandleBitmap, crossSVG, style),
+      ->AttachControl(new NAMSettingsPageControl(b, backgroundBitmap, inputLevelBackgroundBitmap, switchHandleBitmap,
+                                                 crossSVG, style, radioButtonStyle),
                       kCtrlTagSettingsBox)
       ->Hide(true);
 

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -50,11 +50,13 @@ const IVStyle style =
           DEFAULT_SHADOW_OFFSET,
           DEFAULT_WIDGET_FRAC,
           DEFAULT_WIDGET_ANGLE};
-
 const IVStyle titleStyle =
   DEFAULT_STYLE.WithValueText(IText(30, COLOR_WHITE, "Michroma-Regular")).WithDrawFrame(false).WithShadowOffset(2.f);
-
-const IVStyle radioButtonStyle = style.WithColor(EVColor::kON, PluginColors::NAM_THEMEFONTCOLOR);
+const IVStyle radioButtonStyle =
+  style
+    .WithColor(EVColor::kON, PluginColors::NAM_THEMECOLOR) // Pressed buttons and their labels
+    .WithColor(EVColor::kOFF, PluginColors::NAM_THEMECOLOR.WithOpacity(0.1f)) // Unpressed buttons
+    .WithColor(EVColor::kX1, PluginColors::NAM_THEMECOLOR.WithOpacity(0.6f)); // Unpressed buttons' labels
 
 EMsgBoxResult _ShowMessageBox(iplug::igraphics::IGraphics* pGraphics, const char* str, const char* caption,
                               EMsgBoxType type)

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -39,11 +39,11 @@ enum EParams
   // The rest is fine though.
   kNoiseGateActive,
   kEQActive,
-  kOutNorm,
   kIRToggle,
   // Input calibration
   kCalibrateInput,
   kInputCalibrationLevel,
+  kOutputMode,
   kNumParams
 };
 
@@ -56,7 +56,7 @@ enum ECtrlTags
   kCtrlTagInputMeter,
   kCtrlTagOutputMeter,
   kCtrlTagSettingsBox,
-  kCtrlTagOutNorm,
+  kCtrlTagOutputMode,
   kCtrlTagCalibrateInput,
   kCtrlTagInputCalibrationLevel,
   kNumCtrlTags
@@ -216,8 +216,6 @@ private:
   size_t _GetBufferNumChannels() const;
   size_t _GetBufferNumFrames() const;
   void _InitToneStack();
-  // Apply the normalization for the model output (if possible)
-  void _NormalizeModelOutput(iplug::sample** buffer, const size_t numChannels, const size_t numFrames);
   // Loads a NAM model and stores it to mStagedNAM
   // Returns an empty string on success, or an error message on failure.
   std::string _StageModel(const WDL_String& dspFile);
@@ -244,6 +242,7 @@ private:
   void _ResetModelAndIR(const double sampleRate, const int maxBlockSize);
 
   void _SetInputGain();
+  void _SetOutputGain();
 
   // Unserialize current-version plug-in data:
   int _UnserializeStateCurrent(const iplug::IByteChunk& chunk, int startPos);
@@ -273,8 +272,9 @@ private:
   iplug::sample** mInputPointers = nullptr;
   iplug::sample** mOutputPointers = nullptr;
 
-  // Input and (soon) output gain
-  iplug::sample mInputGain = 1.0;
+  // Input and output gain
+  double mInputGain = 1.0;
+  double mOutputGain = 1.0;
 
   // Noise gates
   dsp::noise_gate::Trigger mNoiseGateTrigger;

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -304,7 +304,8 @@ public:
     auto clearFileFunc = [&](IControl* pCaller) {
       pCaller->GetDelegate()->SendArbitraryMsgFromUI(mClearMsgTag);
       mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
-      pCaller->GetUI()->GetControlWithTag(kCtrlTagOutNorm)->SetDisabled(false);
+      // FIXME disabling output mode...
+      //      pCaller->GetUI()->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(false);
     };
 
     auto chooseFileFunc = [&, loadFileFunc](IControl* pCaller) {
@@ -645,7 +646,7 @@ public:
       const float width = titleArea.W();
       const auto inputOutputArea = titleArea.GetFromBottom(height).GetTranslated(0.0f, height);
       const auto inputArea = inputOutputArea.GetFromLeft(0.5f * width);
-      // const auto outputArea = inputOutputArea.GetFromRight(0.5f * width);
+      const auto outputArea = inputOutputArea.GetFromRight(0.5f * width);
 
       const float knobWidth = 87.0f; // HACK based on looking at the main page knobs.
       const auto inputLevelArea =
@@ -662,7 +663,9 @@ public:
         new NAMSwitchControl(inputSwitchArea, kCalibrateInput, "Calibrate Input", mStyle, mSwitchBitmap),
         mControlNames.calibrateInput, kCtrlTagCalibrateInput);
 
-      // TODO output--raw, normalized, calibrated
+      const float buttonSize = 10.0f;
+      AddNamedChildControl(new OutputModeControl(outputArea, kOutputMode, style, buttonSize), mControlNames.outputMode,
+                           kCtrlTagOutputMode);
     }
 
     const float halfWidth = PLUG_WIDTH / 2.0f - pad;
@@ -708,6 +711,7 @@ private:
     const std::string close = "Close";
     const std::string inputCalibrationLevel = "InputCalibrationLevel";
     const std::string modelInfo = "ModelInfo";
+    const std::string outputMode = "OutputMode";
     const std::string title = "Title";
   } mControlNames;
 
@@ -754,6 +758,14 @@ private:
     };
 
     IBitmap mBitmap;
+  };
+
+  class OutputModeControl : public IVRadioButtonControl
+  {
+  public:
+    OutputModeControl(const IRECT& bounds, int paramIdx, const IVStyle& style, float buttonSize)
+    : IVRadioButtonControl(bounds, paramIdx, {"Raw", "Normalized", "Calibrated"}, "Output Mode", style,
+                           EVShape::Ellipse, EDirection::Vertical, buttonSize) {};
   };
 
   class AboutControl : public IContainerBase

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -665,8 +665,11 @@ public:
         new NAMSwitchControl(inputSwitchArea, kCalibrateInput, "Calibrate Input", mStyle, mSwitchBitmap),
         mControlNames.calibrateInput, kCtrlTagCalibrateInput);
 
+      // Same-ish height & width as input controls
+      const auto outputRadioArea =
+        outputArea.GetFromBottom(1.1f * (inputLevelArea.H() + inputSwitchArea.H())).GetMidHPadded(0.55f * knobWidth);
       const float buttonSize = 10.0f;
-      AddNamedChildControl(new OutputModeControl(outputArea, kOutputMode, mRadioButtonStyle, buttonSize),
+      AddNamedChildControl(new OutputModeControl(outputRadioArea, kOutputMode, mRadioButtonStyle, buttonSize),
                            mControlNames.outputMode, kCtrlTagOutputMode);
     }
 

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -556,6 +556,37 @@ private:
   bool mHasInfo = false;
 };
 
+class OutputModeControl : public IVRadioButtonControl
+{
+public:
+  OutputModeControl(const IRECT& bounds, int paramIdx, const IVStyle& style, float buttonSize)
+  : IVRadioButtonControl(
+      bounds, paramIdx, {}, "Output Mode", style, EVShape::Ellipse, EDirection::Vertical, buttonSize) {};
+
+  void SetNormalizedDisable(const bool disable)
+  {
+    // HACK non-DRY string and hard-coded indices
+    std::stringstream ss;
+    ss << "Normalized";
+    if (disable)
+    {
+      ss << " [Not supported by model]";
+    }
+    mTabLabels.Get(1)->Set(ss.str().c_str());
+  };
+  void SetCalibratedDisable(const bool disable)
+  {
+    // HACK non-DRY string and hard-coded indices
+    std::stringstream ss;
+    ss << "Calibrated";
+    if (disable)
+    {
+      ss << " [Not supported by model]";
+    }
+    mTabLabels.Get(2)->Set(ss.str().c_str());
+  };
+};
+
 class NAMSettingsPageControl : public IContainerBaseWithNamedChildren
 {
 public:
@@ -666,8 +697,8 @@ public:
         mControlNames.calibrateInput, kCtrlTagCalibrateInput);
 
       // Same-ish height & width as input controls
-      const auto outputRadioArea =
-        outputArea.GetFromBottom(1.1f * (inputLevelArea.H() + inputSwitchArea.H())).GetMidHPadded(0.55f * knobWidth);
+      const auto outputRadioArea = outputArea.GetFromBottom(
+        1.1f * (inputLevelArea.H() + inputSwitchArea.H())); // .GetMidHPadded(0.55f * knobWidth);
       const float buttonSize = 10.0f;
       AddNamedChildControl(new OutputModeControl(outputRadioArea, kOutputMode, mRadioButtonStyle, buttonSize),
                            mControlNames.outputMode, kCtrlTagOutputMode);
@@ -764,14 +795,6 @@ private:
     };
 
     IBitmap mBitmap;
-  };
-
-  class OutputModeControl : public IVRadioButtonControl
-  {
-  public:
-    OutputModeControl(const IRECT& bounds, int paramIdx, const IVStyle& style, float buttonSize)
-    : IVRadioButtonControl(bounds, paramIdx, {"Raw", "Normalized", "Calibrated"}, "Output Mode", style,
-                           EVShape::Ellipse, EDirection::Vertical, buttonSize) {};
   };
 
   class AboutControl : public IContainerBase

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -560,13 +560,15 @@ class NAMSettingsPageControl : public IContainerBaseWithNamedChildren
 {
 public:
   NAMSettingsPageControl(const IRECT& bounds, const IBitmap& bitmap, const IBitmap& inputLevelBackgroundBitmap,
-                         const IBitmap& switchBitmap, ISVG closeSVG, const IVStyle& style)
+                         const IBitmap& switchBitmap, ISVG closeSVG, const IVStyle& style,
+                         const IVStyle& radioButtonStyle)
   : IContainerBaseWithNamedChildren(bounds)
   , mAnimationTime(0)
   , mBitmap(bitmap)
   , mInputLevelBackgroundBitmap(inputLevelBackgroundBitmap)
   , mSwitchBitmap(switchBitmap)
   , mStyle(style)
+  , mRadioButtonStyle(radioButtonStyle)
   , mCloseSVG(closeSVG)
   {
     mIgnoreMouse = false;
@@ -664,8 +666,8 @@ public:
         mControlNames.calibrateInput, kCtrlTagCalibrateInput);
 
       const float buttonSize = 10.0f;
-      AddNamedChildControl(new OutputModeControl(outputArea, kOutputMode, style, buttonSize), mControlNames.outputMode,
-                           kCtrlTagOutputMode);
+      AddNamedChildControl(new OutputModeControl(outputArea, kOutputMode, mRadioButtonStyle, buttonSize),
+                           mControlNames.outputMode, kCtrlTagOutputMode);
     }
 
     const float halfWidth = PLUG_WIDTH / 2.0f - pad;
@@ -697,6 +699,7 @@ private:
   IBitmap mInputLevelBackgroundBitmap;
   IBitmap mSwitchBitmap;
   IVStyle mStyle;
+  IVStyle mRadioButtonStyle;
   ISVG mCloseSVG;
   int mAnimationTime = 200;
   bool mWillHide = false;


### PR DESCRIPTION
## Description
Implement output calibration. Resolves #529

Normalized output is selected:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/f4ac2dd8-8adf-4962-a779-66c1a912029c">

Example when the model doesn't support output calibration:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/5471b49a-4adb-4d80-a057-dfd86525a873">

And when normalized output isn't supported:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/7dab0abe-45f0-4dcd-a4f8-bc54c2b97f82">

If a non-supported option is chosen, then raw output will be used.

The "Normalize" control is removed from the front page since this extends it:
<img width="596" alt="image" src="https://github.com/user-attachments/assets/462d3193-e156-4abb-b8e2-e6f5e490c703">
 and the default will still be "normalized output" for consistency. Calibrated output is probably most useful for pedal models.

Might want to put some control on the "front page" when the selected output mode isn't supported? Maybe an orange Exclamation point in a circle and make the gear orange? Not sure.

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [x] macOS
- [Y] Does your PR add, remove, or rename any plugin parameters?
  - [N] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
    - _Will do with #526, next_.
