### PR TITLE
Backward-compatible unserialization to v0.7.3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Include [Closing words](https://docs.github.com/en/issues/tracking-your-work-wit
 - [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
   - [ ] Windows
   - [ ] macOS
-- [ ] Does your PR add, remove, or rename any plugin parameters?
-  - [ ] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
+- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
+  - [ ] Have you ensured that the plug-in unserializes correctly?
+  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
   

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -69,6 +69,11 @@ EMsgBoxResult _ShowMessageBox(iplug::igraphics::IGraphics* pGraphics, const char
 #endif
 }
 
+const std::string kCalibrateInputParamName = "CalibrateInput";
+const bool kDefaultCalibrateInput = false;
+const std::string kInputCalibrationLevelParamName = "InputCalibrationLevel";
+const double kDefaultInputCalibrationLevel = 12.0;
+
 
 NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -85,8 +90,9 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
   GetParam(kEQActive)->InitBool("ToneStack", true);
   GetParam(kOutputMode)->InitEnum("OutputMode", 1, {"Raw", "Normalized", "Calibrated"}); // TODO DRY w/ control
   GetParam(kIRToggle)->InitBool("IRToggle", true);
-  GetParam(kCalibrateInput)->InitBool("CalibrateInput", false);
-  GetParam(kInputCalibrationLevel)->InitDouble("InputCalibrationLevel", 12.0, -60.0, 60.0, 0.1, "dBu");
+  GetParam(kCalibrateInput)->InitBool(kCalibrateInputParamName.c_str(), kDefaultCalibrateInput);
+  GetParam(kInputCalibrationLevel)
+    ->InitDouble(kInputCalibrationLevelParamName.c_str(), kDefaultInputCalibrationLevel, -60.0, 60.0, 0.1, "dBu");
 
   mNoiseGateTrigger.AddListener(&mNoiseGateGain);
 
@@ -901,3 +907,6 @@ void NeuralAmpModeler::_UpdateMeters(sample** inputPointer, sample** outputPoint
   mInputSender.ProcessBlock(inputPointer, (int)nFrames, kCtrlTagInputMeter, nChansHack);
   mOutputSender.ProcessBlock(outputPointer, (int)nFrames, kCtrlTagOutputMeter, nChansHack);
 }
+
+// HACK
+#include "Unserialization.cpp"

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -244,11 +244,12 @@ private:
   void _SetInputGain();
   void _SetOutputGain();
 
-  // Unserialize current-version plug-in data:
-  int _UnserializeStateCurrent(const iplug::IByteChunk& chunk, int startPos);
-  // Unserialize v0.7.9 legacy data:
-  int _UnserializeStateLegacy_0_7_9(const iplug::IByteChunk& chunk, int startPos);
-  // And other legacy unsrializations if/as needed...
+  // See: Unserialization.cpp
+  void _UnserializeApplyConfig(nlohmann::json& config);
+  // 0.7.10 and later
+  int _UnserializeStateWithKnownVersion(const IByteChunk& chunk, int startPos);
+  // Hopefully 0.7.9, but no gurantees
+  int _UnserializeStateWithUnknownVersion(const IByteChunk& chunk, int startPos);
 
   // Update all controls that depend on a model
   void _UpdateControlsFromModel();

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -247,9 +247,9 @@ private:
 
   // See: Unserialization.cpp
   void _UnserializeApplyConfig(nlohmann::json& config);
-  // 0.7.10 and later
+  // 0.7.9 and later
   int _UnserializeStateWithKnownVersion(const iplug::IByteChunk& chunk, int startPos);
-  // Hopefully 0.7.9, but no gurantees
+  // Hopefully 0.7.3-0.7.8, but no gurantees
   int _UnserializeStateWithUnknownVersion(const iplug::IByteChunk& chunk, int startPos);
 
   // Update all controls that depend on a model

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -7,6 +7,7 @@
 #include "AudioDSPTools/dsp/wav.h"
 #include "AudioDSPTools/dsp/ResamplingContainer/ResamplingContainer.h"
 
+#include "Colors.h"
 #include "ToneStack.h"
 
 #include "IPlug_include_in_plug_hdr.h"

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -150,7 +150,7 @@ public:
 
   int GetLatency() const { return NeedToResample() ? mResampler.GetLatency() : 0; };
 
-  void Reset(const double sampleRate, const int maxBlockSize)
+  void Reset(const double sampleRate, const int maxBlockSize) override
   {
     mExpectedSampleRate = sampleRate;
     mMaxExternalBlockSize = maxBlockSize;
@@ -247,9 +247,9 @@ private:
   // See: Unserialization.cpp
   void _UnserializeApplyConfig(nlohmann::json& config);
   // 0.7.10 and later
-  int _UnserializeStateWithKnownVersion(const IByteChunk& chunk, int startPos);
+  int _UnserializeStateWithKnownVersion(const iplug::IByteChunk& chunk, int startPos);
   // Hopefully 0.7.9, but no gurantees
-  int _UnserializeStateWithUnknownVersion(const IByteChunk& chunk, int startPos);
+  int _UnserializeStateWithUnknownVersion(const iplug::IByteChunk& chunk, int startPos);
 
   // Update all controls that depend on a model
   void _UpdateControlsFromModel();

--- a/NeuralAmpModeler/Unserialization.cpp
+++ b/NeuralAmpModeler/Unserialization.cpp
@@ -1,13 +1,3 @@
-
-#include <fstream>
-#include <string>
-#include <vector>
-
-#include "json.hpp"
-
-#include "NeuralAmpModeler.h"
-#include "IPlug_include_in_plug_src.h"
-
 // Unserialization
 //
 // This plugin is used in important places, so we need to be considerate when

--- a/NeuralAmpModeler/Unserialization.cpp
+++ b/NeuralAmpModeler/Unserialization.cpp
@@ -117,8 +117,18 @@ void _UpdateConfigFrom_0_7_12(nlohmann::json& config)
 int _GetConfigFrom_0_7_12(const iplug::IByteChunk& chunk, int startPos, nlohmann::json& config)
 {
   int pos = startPos;
-  std::vector<std::string> paramNames{"Input",  "Threshold",       "Bass",      "Middle",     "Treble",
-                                      "Output", "NoiseGateActive", "ToneStack", "OutputMode", "IRToggle"};
+  std::vector<std::string> paramNames{"Input",
+                                      "Threshold",
+                                      "Bass",
+                                      "Middle",
+                                      "Treble",
+                                      "Output",
+                                      "NoiseGateActive",
+                                      "ToneStack",
+                                      "IRToggle",
+                                      "CalibrateInput",
+                                      "InputCalibrationLevel",
+                                      "OutputMode"};
 
   pos = _UnserializePathsAndExpectedKeys(chunk, pos, config, paramNames);
   // Then update:
@@ -256,6 +266,10 @@ int NeuralAmpModeler::_UnserializeStateWithKnownVersion(const iplug::IByteChunk&
   else if (version >= _Version(0, 7, 10))
   {
     pos = _GetConfigFrom_0_7_10(chunk, pos, config);
+  }
+  else if (version >= _Version(0, 7, 9))
+  {
+    pos = _GetConfigFrom_Earlier(chunk, pos, config);
   }
   else
   {

--- a/NeuralAmpModeler/Unserialization.cpp
+++ b/NeuralAmpModeler/Unserialization.cpp
@@ -1,0 +1,282 @@
+
+#include <ifstream>
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+
+#include "NeuralAmpModeler.h"
+
+// Unserialization
+//
+// This plugin is used in important places, so we need to be considerate when
+// attempting to unserialize. If the project was last saved with a legacy
+// version, then we need it to "update" to the current version is as
+// reasonable a way as possible.
+//
+// In order to handle older versions, the pattern is:
+// 1. Implement unserialization for every version into a version-specific
+//    struct (Let's use our friend nlohmann::json. Why not?)
+// 2. Implement an "update" from each struct to the next one.
+// 3. Implement assigning the data contained in the current struct to the
+//    current plugin configuration.
+//
+// This way, a constant amount of effort is required every time the
+// serialization changes instead of having to implement a current
+// unserialization for each past version.
+
+// Add new unserialization versions to the top, then add logic to the class method at the bottom.
+
+// Boilerplate
+
+void NeuralAmpModeler::_UnserializeApplyConfig(nlohmann::json& config)
+{
+  // cf IPluginBase::UnserializeParams(const IByteChunk& chunk, int startPos)
+
+  nlohmann::json config;
+
+  auto getParamByName = [&, newNames](std::string& name) {
+    // Could use a map but eh
+    for (int i = 0; i < kNumParams; i++)
+    {
+      IParam* param = GetParam(i);
+      if (strcmp(param->GetName(), name.c_str()) == 0)
+      {
+        return param;
+      }
+    }
+    // else
+    return (IParam*)nullptr;
+  };
+  TRACE
+  ENTER_PARAMS_MUTEX
+  int i = 0;
+  for (auto it = config.begin(); it != config.end(); ++it, i++)
+  {
+    IParam* pParam = getParamByName(it->first);
+    if (pParam != nullptr)
+    {
+      pParam->Set(v);
+      Trace(TRACELOC, "%d %s %f", i, pParam->GetName(), pParam->Value());
+    }
+    else
+    {
+      Trace(TRACELOC, "%s NOT-FOUND", it->first.c_str());
+    }
+  }
+  OnParamReset(kPresetRecall);
+  LEAVE_PARAMS_MUTEX
+
+  mNAMPath.Set(config["NAMPath"].c_str());
+  mIRPath.Set(config["IRPath"].c_str());
+
+  if (mNAMPath.GetLength())
+  {
+    _StageModel(mNAMPath);
+  }
+  if (mIRPath.GetLength())
+  {
+    _StageIR(mIRPath);
+  }
+}
+
+// Unserialize NAM Path, IR path, then named keys
+int _UnserializePathsAndExpectedKeys(const IByteChunk& chunk, inst startPos, nlohmann::json& config,
+                                     std::vector<std::string>& paramNames)
+{
+  int pos = startPos;
+  WDL_String path;
+  pos = chunk.GetStr(path, pos);
+  config["NAMPath"] = std::string(path.Get());
+  pos = chunk.GetStr(path, pos);
+  config["IRPath"] = std::string(path.Get());
+
+  for (auto it = paramNames.begin(); it != paramNames.end(); ++it)
+  {
+    double v = 0.0;
+    pos = chunk.Get(&v, pos);
+    config[*it] = v;
+  }
+  return pos;
+}
+
+void _RenameKeys(nlohmann::json& j, std::unordered_map<std::string, std::string> newNames)
+{
+  // Assumes no aliasing!
+  for (it = newNames.begin(); it != newNames.end(); ++it)
+  {
+    config[it->first] = config[it->second];
+    config.erase(it->first);
+  }
+}
+
+// v0.7.12
+
+void _UpdateConfigFrom_0_7_12(nlohmann::json& config)
+{
+  // Fill me in once something changes!
+}
+
+int _GetConfigFrom_0_7_12(const IByteChunk& chunk, int pos, nlohmann::json& config)
+{
+  int pos = startPos;
+  nlohmann::json config;
+  std::vector<std::string> paramNames{"Input",  "Threshold",       "Bass",      "Middle",     "Treble",
+                                      "Output", "NoiseGateActive", "ToneStack", "OutputMode", "IRToggle"};
+
+  pos = _UnserializePathsAndExpectedKeys(chunk, pos, config, paramNames);
+  // Then update:
+  _UnserializeUpdateFrom_0_7_12(config);
+  _UnserializeFromJson(config);
+  return pos;
+}
+
+// 0.7.10
+
+void _UpdateConfigFrom_0_7_10(nlohmann::json& config)
+{
+  std::unordered_map<std::string, std::string> newNames{{"OutNorm", "OutputMode"}};
+  _RenameKeys(config, newNames);
+  _UnserializeUpdateFrom_0_7_12(config);
+}
+
+int _GetConfigFrom_0_7_10(const IByteChunk& chunk, int startPos, nlohmann::json& config)
+{
+  int pos = startPos;
+  nlohmann::json config;
+  std::vector<std::string> paramNames{
+    "Input", "Threshold", "Bass", "Middle", "Treble", "Output", "NoiseGateActive", "ToneStack", "OutNorm", "IRToggle"};
+
+  pos = _UnserializePathsAndExpectedKeys(chunk, pos, config, paramNames);
+  // Then update:
+  _UnserializeUpdateFrom_0_7_10(config);
+  _UnserializeFromJson(config);
+  return pos;
+}
+
+// Earlier than 0.7.10 (Assumed to be 0.7.9)
+
+void _UpdateConfigFrom_Earlier(nlohmann::json& config)
+{
+  std::unordered_map<std::string, std::string> newNames{{"Gate", "Threshold"}};
+  _RenameKeys(config, newNames);
+  _UpdateConfigFrom_0_7_10(config);
+}
+
+int _GetConfigFrom_Earlier(const IByteChunk& chunk, int startPos, nlohmann::json& config)
+{
+  int pos = startPos;
+  std::vector<std::string> paramNames{
+    "Input", "Gate", "Bass", "Middle", "Treble", "Output", "NoiseGateActive", "ToneStack", "OutNorm", "IRToggle"};
+
+  pos = _UnserializePathsAndExpectedKeys(chunk, pos, config, paramNames);
+  // Then update:
+  _UpdateConfigFrom_Earlier(config);
+  _UnserializeFromJson(config);
+  return pos;
+}
+
+//==============================================================================
+
+class _Version
+{
+public:
+  _Version(const int major, const int minor, const int patch)
+  : mMajor(major)
+  , mMinor(minor)
+  , mPatch(patch) {};
+  _Version(const std::string& versionStr)
+  {
+    std::istringstream stream(versionStr);
+    std::string token;
+    std::vector<int> parts;
+
+    // Split the string by "."
+    while (std::getline(stream, token, '.'))
+    {
+      parts.push_back(std::stoi(token)); // Convert to int and store
+    }
+
+    // Check if we have exactly 3 parts
+    if (parts.size() != 3)
+    {
+      throw std::invalid_argument("Input string does not contain exactly 3 segments separated by '.'");
+    }
+
+    // Assign the parts to the provided int variables
+    mMajor = parts[0];
+    mMinor = parts[1];
+    mPatch = parts[2];
+  };
+
+  bool operator<=(const _Version& other) const
+  {
+    // Compare on major version:
+    if (other.GetMajor() > GetMajor())
+    {
+      return true;
+    }
+    if (other.GetMajor() < GetMajor())
+    {
+      return false;
+    }
+    // Compare on minor
+    if (other.GetMinor() > GetMinor())
+    {
+      return true;
+    }
+    if (other.GetMinor() < GetMinor())
+    {
+      return false;
+    }
+    // Compare on patch
+    return other.GetPatch() <= GetPatch();
+
+    int GetMajor() const
+    {
+      return mMajor;
+    };
+    int GetMinor() const
+    {
+      return mMinor;
+    };
+    int GetPatch() const
+    {
+      return mPatch;
+    };
+
+  private:
+    int mMajor;
+    int mMinor;
+    int mPatch;
+  };
+};
+
+int NeuralAmpModeler::_UnserializeStateWithKnownVersion(const IByteChunk& chunk, int startPos)
+{
+  // We already got through the header before calling this.
+  int pos = startPos;
+
+  // Get the version
+  WDL_String wVersion;
+  pos = chunk.GetStr(wVersion, pos);
+  std::string versionStr(wVersion.Get());
+  _Version version(versionStr);
+  // Act accordingly
+  nlohmann::json config;
+  if (version >= _Version(0, 7, 12))
+  {
+    pos _GetConfigFrom_0_7_12(chunk, pos, config);
+  }
+  else if (version >= _Version(0, 7, 10))
+  {
+    pos _GetConfigFrom_0_7_10(chunk, pos, config);
+  }
+  else
+  {
+    // You shouldn't be here...
+    assert(false);
+  }
+  _UnserializeApplyConfig(config);
+  return pos;
+}


### PR DESCRIPTION
**Thanks for making a Pull Request!**
Please fill out this template so that you can be sure that your PR does everything it needs to be accepted.

## Description
Older versions of the plugin back to 0.7.3 (maybe 0.7.0) unserialize into a reasonable state for the current version.
Resolves #526.

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [x] macOS
- [x] Does your PR add, remove, or rename any plugin parameters?
  - [x] If yes, then have you ensured that older versions of the plug-in load correctly? (Usually, this means writing a new legacy unserialization function like [`_UnserializeStateLegacy_0_7_9`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/f755918e3f325f28658700ca954f8a47ec58d021/NeuralAmpModeler/NeuralAmpModeler.cpp#L823).)
  
