### PR TITLE
Fixing issue #541 where Nexus and potentially other VST/plugin hosts crash and exit unexpectedly on NAM Plugin UI open

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -785,6 +785,7 @@ private:
       IControl::SetValueFromDelegate(normalizedValue, valIdx);
       const std::string s = ConvertToString(normalizedValue);
       SetStr(s.c_str());
+      SetDirty(false);
     };
 
   private:

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -784,7 +784,7 @@ private:
     {
       IControl::SetValueFromDelegate(normalizedValue, valIdx);
       const std::string s = ConvertToString(normalizedValue);
-      OnTextEntryCompletion(s.c_str(), valIdx);
+      SetStr(s.c_str());
     };
 
   private:


### PR DESCRIPTION
Provides a suggested fix to #541 where NeuralAmpModelerPlugin causes plugin host(s) to crash and/or exit unexpectedly.

## Description
What does your PR do?
Provides a suggested fix #541 .

## PR Checklist
- [X] Did you format your code using [`format.bash`] N/A - single line

- [X] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [X] Windows
  - [x] macOS

- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [ ] Have you ensured that the plug-in unserializes correctly?
  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
 
  
