### PR TITLE
File Browser Control "Get" models and irs buttons with dynamic clear button

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -225,17 +225,18 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     const std::string defaultNamFileString = "Select model...";
     const std::string defaultIRString = "Select IR...";
 #endif
+    // Getting started page listing 3-rd party sites to get NAM models and IRs
+    const char* const getUrl = "https://www.neuralampmodeler.com/users#comp-li85mj7o";
     pGraphics->AttachControl(
       new NAMFileBrowserControl(modelArea, kMsgTagClearModel, defaultNamFileString.c_str(), "nam",
                                 loadModelCompletionHandler, style, fileSVG, crossSVG, leftArrowSVG, rightArrowSVG,
-                                fileBackgroundBitmap, globeSVG, "Get NAM Models",
-                                "https://tonehunt.org/popular?tags%5B0%5D=nam"),
+                                fileBackgroundBitmap, globeSVG, "Get NAM Models", getUrl),
       kCtrlTagModelFileBrowser);
     pGraphics->AttachControl(new ISVGSwitchControl(irSwitchArea, {irIconOffSVG, irIconOnSVG}, kIRToggle));
     pGraphics->AttachControl(
       new NAMFileBrowserControl(irArea, kMsgTagClearIR, defaultIRString.c_str(), "wav", loadIRCompletionHandler, style,
                                 fileSVG, crossSVG, leftArrowSVG, rightArrowSVG, fileBackgroundBitmap, globeSVG,
-                                "Get IRs", "https://tonehunt.org/popular?filter=ir"),
+                                "Get IRs", getUrl),
       kCtrlTagIRFileBrowser);
     pGraphics->AttachControl(
       new NAMSwitchControl(ngToggleArea, kNoiseGateActive, "Noise Gate", style, switchHandleBitmap));

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -225,8 +225,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     const std::string defaultNamFileString = "Select model...";
     const std::string defaultIRString = "Select IR...";
 #endif
-    // Getting started page listing 3-rd party sites to get NAM models and IRs
-    const char* const getUrl = "https://www.neuralampmodeler.com/users#comp-li85mj7o";
+    // Getting started page listing additional resources
+    const char* const getUrl = "https://www.neuralampmodeler.com/users#comp-marb84o5";
     pGraphics->AttachControl(
       new NAMFileBrowserControl(modelArea, kMsgTagClearModel, defaultNamFileString.c_str(), "nam",
                                 loadModelCompletionHandler, style, fileSVG, crossSVG, leftArrowSVG, rightArrowSVG,

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -119,6 +119,7 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
 
     const auto gearSVG = pGraphics->LoadSVG(GEAR_FN);
     const auto fileSVG = pGraphics->LoadSVG(FILE_FN);
+    const auto globeSVG = pGraphics->LoadSVG(GLOBE_ICON_FN);
     const auto crossSVG = pGraphics->LoadSVG(CLOSE_BUTTON_FN);
     const auto rightArrowSVG = pGraphics->LoadSVG(RIGHT_ARROW_FN);
     const auto leftArrowSVG = pGraphics->LoadSVG(LEFT_ARROW_FN);
@@ -224,14 +225,17 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     const std::string defaultNamFileString = "Select model...";
     const std::string defaultIRString = "Select IR...";
 #endif
-    pGraphics->AttachControl(new NAMFileBrowserControl(modelArea, kMsgTagClearModel, defaultNamFileString.c_str(),
-                                                       "nam", loadModelCompletionHandler, style, fileSVG, crossSVG,
-                                                       leftArrowSVG, rightArrowSVG, fileBackgroundBitmap),
-                             kCtrlTagModelFileBrowser);
+    pGraphics->AttachControl(
+      new NAMFileBrowserControl(modelArea, kMsgTagClearModel, defaultNamFileString.c_str(), "nam",
+                                loadModelCompletionHandler, style, fileSVG, crossSVG, leftArrowSVG, rightArrowSVG,
+                                fileBackgroundBitmap, globeSVG, "Get NAM Models",
+                                "https://tonehunt.org/popular?tags%5B0%5D=nam"),
+      kCtrlTagModelFileBrowser);
     pGraphics->AttachControl(new ISVGSwitchControl(irSwitchArea, {irIconOffSVG, irIconOnSVG}, kIRToggle));
     pGraphics->AttachControl(
       new NAMFileBrowserControl(irArea, kMsgTagClearIR, defaultIRString.c_str(), "wav", loadIRCompletionHandler, style,
-                                fileSVG, crossSVG, leftArrowSVG, rightArrowSVG, fileBackgroundBitmap),
+                                fileSVG, crossSVG, leftArrowSVG, rightArrowSVG, fileBackgroundBitmap, globeSVG,
+                                "Get IRs", "https://tonehunt.org/popular?filter=ir"),
       kCtrlTagIRFileBrowser);
     pGraphics->AttachControl(
       new NAMSwitchControl(ngToggleArea, kNoiseGateActive, "Noise Gate", style, switchHandleBitmap));

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -12,6 +12,12 @@
 using namespace iplug;
 using namespace igraphics;
 
+enum class NAMBrowserState
+{
+  Empty, // when no file loaded, show "Get" button
+  Loaded // when ile loaded, show "Clear" button
+};
+
 // Where the corner button on the plugin (settings, close settings) goes
 // :param rect: Rect for the whole plugin's UI
 IRECT CornerButtonArea(const IRECT& rect)
@@ -209,12 +215,30 @@ public:
   }
 };
 
+// URL control for the "Get" models/irs links
+class NAMGetButtonControl : public NAMSquareButtonControl
+{
+public:
+  NAMGetButtonControl(const IRECT& bounds, const char* label, const char* url, const ISVG& globeSVG)
+  : NAMSquareButtonControl(
+      bounds,
+      [url](IControl* pCaller) {
+        WDL_String fullURL(url);
+        pCaller->GetUI()->OpenURL(fullURL.Get());
+      },
+      globeSVG)
+  {
+    SetTooltip(label);
+  }
+};
+
 class NAMFileBrowserControl : public IDirBrowseControlBase
 {
 public:
   NAMFileBrowserControl(const IRECT& bounds, int clearMsgTag, const char* labelStr, const char* fileExtension,
                         IFileDialogCompletionHandlerFunc ch, const IVStyle& style, const ISVG& loadSVG,
-                        const ISVG& clearSVG, const ISVG& leftSVG, const ISVG& rightSVG, const IBitmap& bitmap)
+                        const ISVG& clearSVG, const ISVG& leftSVG, const ISVG& rightSVG, const IBitmap& bitmap,
+                        const ISVG& globeSVG, const char* getButtonLabel, const char* getButtonURL)
   : IDirBrowseControlBase(bounds, fileExtension, false, false)
   , mClearMsgTag(clearMsgTag)
   , mDefaultLabelStr(labelStr)
@@ -225,6 +249,10 @@ public:
   , mClearSVG(clearSVG)
   , mLeftSVG(leftSVG)
   , mRightSVG(rightSVG)
+  , mGlobeSVG(globeSVG)
+  , mGetButtonLabel(getButtonLabel)
+  , mGetButtonURL(getButtonURL)
+  , mBrowserState(NAMBrowserState::Empty)
   {
     mIgnoreMouse = true;
   }
@@ -304,6 +332,7 @@ public:
     auto clearFileFunc = [&](IControl* pCaller) {
       pCaller->GetDelegate()->SendArbitraryMsgFromUI(mClearMsgTag);
       mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
+      SetBrowserState(NAMBrowserState::Empty);
       // FIXME disabling output mode...
       //      pCaller->GetUI()->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(false);
     };
@@ -328,7 +357,7 @@ public:
     IRECT padded = mRECT.GetPadded(-6.f).GetHPadded(-2.f);
     const auto buttonWidth = padded.H();
     const auto loadFileButtonBounds = padded.ReduceFromLeft(buttonWidth);
-    const auto clearButtonBounds = padded.ReduceFromRight(buttonWidth);
+    const auto clearAndGetButtonBounds = padded.ReduceFromRight(buttonWidth);
     const auto leftButtonBounds = padded.ReduceFromLeft(buttonWidth);
     const auto rightButtonBounds = padded.ReduceFromLeft(buttonWidth);
     const auto fileNameButtonBounds = padded;
@@ -341,10 +370,17 @@ public:
       ->SetAnimationEndActionFunction(nextFileFunc);
     AddChildControl(mFileNameControl = new NAMFileNameControl(fileNameButtonBounds, mDefaultLabelStr.Get(), mStyle))
       ->SetAnimationEndActionFunction(chooseFileFunc);
-    AddChildControl(new NAMSquareButtonControl(clearButtonBounds, DefaultClickActionFunc, mClearSVG))
-      ->SetAnimationEndActionFunction(clearFileFunc);
 
-    mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
+    // creates both right-side controls but only show one based on state
+    mClearButton = new NAMSquareButtonControl(clearAndGetButtonBounds, DefaultClickActionFunc, mClearSVG);
+    mClearButton->SetAnimationEndActionFunction(clearFileFunc);
+    AddChildControl(mClearButton);
+
+    mGetButton = new NAMGetButtonControl(clearAndGetButtonBounds, mGetButtonLabel, mGetButtonURL, mGlobeSVG);
+    AddChildControl(mGetButton);
+
+    // initialize control visibility
+    SetBrowserState(NAMBrowserState::Empty);
   }
 
   void LoadFileAtCurrentIndex()
@@ -367,6 +403,7 @@ public:
         {
           std::string label(std::string("(FAILED) ") + std::string(mFileNameControl->GetLabelStr()));
           mFileNameControl->SetLabelAndTooltip(label.c_str());
+          SetBrowserState(NAMBrowserState::Empty);
         }
         break;
       case kMsgTagLoadedModel:
@@ -382,8 +419,9 @@ public:
         SetupMenu();
         SetSelectedFile(fileName.Get());
         mFileNameControl->SetLabelAndTooltipEllipsizing(fileName);
-        break;
+        SetBrowserState(NAMBrowserState::Loaded);
       }
+      break;
       default: break;
     }
   }
@@ -398,13 +436,38 @@ private:
     return;
   }
 
+  // set the state of the browser and the visibility of the "Get" vs. "Clear" buttons
+  void SetBrowserState(NAMBrowserState newState)
+  {
+    mBrowserState = newState;
+
+    switch (mBrowserState)
+    {
+      case NAMBrowserState::Empty:
+        mClearButton->Hide(true);
+        mGetButton->Hide(false);
+        break;
+      case NAMBrowserState::Loaded:
+        mClearButton->Hide(false);
+        mGetButton->Hide(true);
+        break;
+    }
+  }
+
   WDL_String mDefaultLabelStr;
   IFileDialogCompletionHandlerFunc mCompletionHandlerFunc;
   NAMFileNameControl* mFileNameControl = nullptr;
   IVStyle mStyle;
   IBitmap mBitmap;
-  ISVG mLoadSVG, mClearSVG, mLeftSVG, mRightSVG;
+  ISVG mLoadSVG, mClearSVG, mLeftSVG, mRightSVG, mGlobeSVG;
   int mClearMsgTag;
+
+  // new members for the "Get" button
+  const char* mGetButtonLabel;
+  const char* mGetButtonURL;
+  NAMBrowserState mBrowserState;
+  NAMSquareButtonControl* mClearButton = nullptr;
+  NAMGetButtonControl* mGetButton = nullptr;
 };
 
 class NAMMeterControl : public IVPeakAvgMeterControl<>, public IBitmapBase

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -15,7 +15,7 @@ using namespace igraphics;
 enum class NAMBrowserState
 {
   Empty, // when no file loaded, show "Get" button
-  Loaded // when ile loaded, show "Clear" button
+  Loaded // when file loaded, show "Clear" button
 };
 
 // Where the corner button on the plugin (settings, close settings) goes

--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -67,6 +67,7 @@
 #define MODEL_ICON_FN "ModelIcon.svg"
 #define IR_ICON_ON_FN "IRIconOn.svg"
 #define IR_ICON_OFF_FN "IRIconOff.svg"
+#define GLOBE_ICON_FN "Globe.svg"
 
 #define BACKGROUND_FN "Background.jpg"
 #define BACKGROUND2X_FN "Background@2x.jpg"

--- a/NeuralAmpModeler/resources/img/Globe.svg
+++ b/NeuralAmpModeler/resources/img/Globe.svg
@@ -1,0 +1,5 @@
+<svg width="800" height="800" viewBox="0 0 800 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M400 700C565.685 700 700 565.685 700 400C700 234.315 565.685 100 400 100C234.315 100 100 234.315 100 400C100 565.685 234.315 700 400 700Z" stroke="#5D83E2" stroke-width="45" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M400 99.9999C322.967 180.884 280 288.302 280 400C280 511.698 322.967 619.115 400 700C477.033 619.115 520 511.698 520 400C520 288.302 477.033 180.884 400 99.9999Z" stroke="#5D83E2" stroke-width="45" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M100 399.993H700" stroke="#5D83E2" stroke-width="45" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Description

After taking on ToneHunt support I've found NAM newbies often download this plugin but struggle to figure out how to get models. While users like Robert (screenshot below) will do the research or ask in the FB group, I believe a much larger group quietly gives up and leaves NAM for good. I’ve seen this firsthand with several friends I’ve introduced to NAM. To address this issue, this PR adds "Get" buttons to the File Browser Control. These buttons only appear when the File Browser state is empty, replacing the unneeded/redundant "Clear" buttons. The "Get NAM Models" button deep links to ~all the NAM models on ToneHunt~ the "NAM for users" page on neuralampmodeler.com anchored to the share/find section. The "Get IRs" button deep links to ~all the IRs on ToneHunt~ the "NAM for users" page on neuralampmodeler.com anchored to the share/find section. See video demo below:

https://github.com/user-attachments/assets/199de400-0185-4dc0-93f4-6eaeb3734964

While I understand the purpose of the NeuralAmpModelerPlugin is primarily to demo the core tech, I think in reality it is actually a well distributed entry point for NAM consumers and therefore IMO this gap in "getting started" should be solved in some way. We are currently working on offering a search API as well as a webview embed integration for plugin makers to allow their users to directly search/download from ToneHunt. However, that approach may be overkill for the philosophy behind this plugin. Here, I tried to solve the issue as dead simple as possible, with very little code to change/maintain and with as little visual footprint as possible.

Examples:
![image](https://github.com/user-attachments/assets/72adcdd6-7335-48cd-acb3-7de8a4421fbf)
https://youtu.be/wIPoLLDUMlU?t=41 (This YouTube influencer shares his first impression of the NAM plugin, highlighting confusion around finding models. Notably, this is my top result when searching 'Neural Amp Modeler' on YouTube.)

Related Github Issues:
https://github.com/sdatkinson/NeuralAmpModelerPlugin/issues/438
https://github.com/sdatkinson/NeuralAmpModelerPlugin/issues/122
https://github.com/sdatkinson/NeuralAmpModelerPlugin/issues/191
https://github.com/sdatkinson/NeuralAmpModelerPlugin/issues/112
https://github.com/sdatkinson/NeuralAmpModelerPlugin/issues/136

Here are a couple alternative designs we came up with:
https://www.figma.com/design/W0gS44o9rBXhplC77vCeBQ/NAM-Plugin-Options?node-id=0-1&p=f&t=BkqVnupGpgSqfVK7-0 

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [x] macOS
- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [ ] Have you ensured that the plug-in unserializes correctly?
  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
  