### PR TITLE
Add support for embedding NAM models and IR files in session data

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -220,10 +220,14 @@ private:
   // Loads a NAM model and stores it to mStagedNAM
   // Returns an empty string on success, or an error message on failure.
   std::string _StageModel(const WDL_String& dspFile);
+  // Loads a NAM model from embedded binary data
+  std::string _StageModelFromData(const std::vector<uint8_t>& data, const WDL_String& originalPath);
   // Loads an IR and stores it to mStagedIR.
   // Return status code so that error messages can be relayed if
   // it wasn't successful.
   dsp::wav::LoadReturnCode _StageIR(const WDL_String& irPath);
+  // Loads an IR from embedded binary data
+  dsp::wav::LoadReturnCode _StageIRFromData(const std::vector<uint8_t>& data, const WDL_String& originalPath);
 
   bool _HaveModel() const { return this->mModel != nullptr; };
   // Prepare the input & output buffers
@@ -306,6 +310,10 @@ private:
   WDL_String mNAMPath;
   // Path to IR (.wav file)
   WDL_String mIRPath;
+
+  // Embedded file data for portability (stored with DAW session)
+  std::vector<uint8_t> mNAMData;
+  std::vector<uint8_t> mIRData;
 
   WDL_String mHighLightColor{PluginColors::NAM_THEMECOLOR.ToColorCode()};
 


### PR DESCRIPTION
## Description
This PR adds the ability to embed NAM model files (.nam) and impulse response files (.wav) directly into DAW session/project files, making sessions fully portable and self-contained.

### Features
- **Automatic Embedding**: When saving a session, NAM models and IR files are encoded and embedded in the plugin state
- **Automatic Extraction**: When loading a session, embedded files are extracted to temporary files and loaded automatically
- **Backward Compatible**: Sessions without embedded data continue to work with file paths as before
- **Cross-Platform**: Designed to work on Windows, macOS, and Linux

### Benefits
- Share sessions without worrying about missing model/IR files
- Old projects remain playable even if original files are moved/deleted
- Team members can open sessions without manual file management

### Implementation
- Modified `SerializeState()` to embed file contents in session data
- Modified `UnserializeState()` to detect and extract embedded files automatically
- Added `_StageModelFromData()` and `_StageIRFromData()` helper methods for loading from memory
- Maintain backward compatibility with file path references
- Update AudioDSPTools submodule to include SIGFPE fix (depends on sdatkinson/AudioDSPTools#24)

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)?
  - [x] Windows - Validated with pluginval (strictness level 5) - **SUCCESS**
  - [ ] macOS - **Unable to test**: VMware Sonoma 14.7.2 + Xcode 16.2 environment has NanoVG/Metal incompatibility issues. Recommend testing via GitHub Actions CI which uses Xcode 15.x.
- [x] Does your PR add, remove, or rename any plugin parameters? **No**
- [x] Does your PR add or remove any graphical assets? **No**

## Testing Notes
### Windows (Validated ✅)
- Build: Visual Studio 2022, x64 Release
- Validation: pluginval v1.x, strictness level 5
- Results: All tests passed (audio processing, automation, state save/restore, editor, bus configuration)

### macOS (Limited Testing ⚠️)
**Note**: Local macOS testing was not possible due to environmental constraints:
- Test environment: VMware Sonoma 14.7.2 + Xcode 16.2
- Issue: NanoVG/Metal incompatibility causing image loading crashes (not related to this PR)
- Official v0.7.13 release also crashes in this environment
- **Recommendation**: Please test via GitHub Actions CI, which uses Xcode 15.x and should work correctly

The embedding code itself is platform-independent and uses standard C++ file I/O. The implementation should work on macOS, but comprehensive validation via CI is recommended.



## Files Changed
NeuralAmpModeler.cpp: Embedding/extraction logic and helper methods (+260 lines)
NeuralAmpModeler.h: Added mNAMData and mIRData member variables (+8 lines)
Unserialization.cpp: Added embedded data extraction with versioned functions for 0.7.13 (+134 lines)
  
