### PR TITLE
Fix missing path separator in prepare_resources-mac.py

### DIFF
--- a/NeuralAmpModeler/scripts/prepare_resources-mac.py
+++ b/NeuralAmpModeler/scripts/prepare_resources-mac.py
@@ -31,9 +31,9 @@ def main():
             + "/Resources"
         )
     else:
-        dst = (
-            os.environ["TARGET_BUILD_DIR"]
-            + os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
+        dst = os.path.join(
+            os.environ["TARGET_BUILD_DIR"],
+            os.environ["UNLOCALIZED_RESOURCES_FOLDER_PATH"]
         )
 
     if os.path.exists(dst) == False:


### PR DESCRIPTION
**Thanks for making a Pull Request!**
Please fill out this template so that you can be sure that your PR does everything it needs to be accepted.

## Description
Fixes a bug in the macOS resource copying script where `TARGET_BUILD_DIR` and `UNLOCALIZED_RESOURCES_FOLDER_PATH` were concatenated without a path separator, causing resources to be copied to an invalid path.

**Before:** `/Users/name/ApplicationsApp.app/Contents/Resources` (missing slash)
**After:** `/Users/name/Applications/App.app/Contents/Resources` (correct)

This caused the standalone app to crash on startup with a segmentation fault when trying to render UI elements with missing bitmaps.

## PR Checklist (none are applicable for this change)
- [ ] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [ ] macOS
- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [ ] Have you ensured that the plug-in unserializes correctly?
  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
- [ ] Does your PR add or remove any graphical assets? If yes, are they defined in [config.h](https://github.com/olilarkin/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/config.h) and added in the two required locations in [main.rc](https://github.com/olilarkin/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/resources/main.rc)?
  
