### PR TITLE
[ENHANCEMENT] NeuralAmpModelerCore v0.4.0.rc3

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -693,7 +693,7 @@ std::string NeuralAmpModeler::_StageModel(const WDL_String& modelPath)
   {
     auto dspPath = std::filesystem::u8path(modelPath.Get());
     std::unique_ptr<nam::DSP> model = nam::get_dsp(dspPath);
-    
+
     // Check that the model has 1 input and 1 output channel
     if (model->NumInputChannels() != 1)
     {
@@ -701,9 +701,10 @@ std::string NeuralAmpModeler::_StageModel(const WDL_String& modelPath)
     }
     if (model->NumOutputChannels() != 1)
     {
-      throw std::runtime_error("Model must have 1 output channel, but has " + std::to_string(model->NumOutputChannels()));
+      throw std::runtime_error("Model must have 1 output channel, but has "
+                               + std::to_string(model->NumOutputChannels()));
     }
-    
+
     std::unique_ptr<ResamplingNAM> temp = std::make_unique<ResamplingNAM>(std::move(model), GetSampleRate());
     temp->Reset(GetSampleRate(), GetBlockSize());
     mStagedModel = std::move(temp);

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -322,7 +322,7 @@ void NeuralAmpModeler::ProcessBlock(iplug::sample** inputs, iplug::sample** outp
 
   if (mModel != nullptr)
   {
-    mModel->process(triggerOutput[0], mOutputPointers[0], nFrames);
+    mModel->process(triggerOutput, mOutputPointers, nFrames);
   }
   else
   {
@@ -693,6 +693,17 @@ std::string NeuralAmpModeler::_StageModel(const WDL_String& modelPath)
   {
     auto dspPath = std::filesystem::u8path(modelPath.Get());
     std::unique_ptr<nam::DSP> model = nam::get_dsp(dspPath);
+    
+    // Check that the model has 1 input and 1 output channel
+    if (model->NumInputChannels() != 1)
+    {
+      throw std::runtime_error("Model must have 1 input channel, but has " + std::to_string(model->NumInputChannels()));
+    }
+    if (model->NumOutputChannels() != 1)
+    {
+      throw std::runtime_error("Model must have 1 output channel, but has " + std::to_string(model->NumOutputChannels()));
+    }
+    
     std::unique_ptr<ResamplingNAM> temp = std::make_unique<ResamplingNAM>(std::move(model), GetSampleRate());
     temp->Reset(GetSampleRate(), GetBlockSize());
     mStagedModel = std::move(temp);

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-aax.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="PaceFixLogs" AssemblyFile="$(PACE_FUSION_HOME)PaceFusionUi2013.dll" />
   <ItemGroup Label="ProjectConfigurations">
@@ -416,6 +416,7 @@
     <ClCompile Include="..\..\AudioDSPTools\dsp\wav.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\activations.cpp" />
+    <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\conv1d.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\convnet.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\dsp.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
@@ -427,6 +428,7 @@
     </ClCompile>
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\get_dsp.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\lstm.cpp" />
+    <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\ring_buffer.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\util.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\wavenet.cpp" />
     <ClCompile Include="..\ToneStack.cpp" />
@@ -528,10 +530,15 @@
     <ClInclude Include="..\NeuralAmpModeler.h" />
     <ClInclude Include="..\NeuralAmpModelerControls.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\activations.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\conv1d.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\convnet.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\film.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\gating_activations.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\get_dsp.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\lstm.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\registry.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\ring_buffer.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\util.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\version.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\wavenet.h" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="PaceFixLogs" AssemblyFile="$(PACE_FUSION_HOME)PaceFusionUi2013.dll" />
   <ItemGroup Label="ProjectConfigurations">
@@ -335,10 +335,15 @@
     <ClInclude Include="..\NeuralAmpModeler.h" />
     <ClInclude Include="..\NeuralAmpModelerControls.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\activations.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\conv1d.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\convnet.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\film.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\gating_activations.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\get_dsp.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\lstm.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\registry.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\ring_buffer.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\util.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\version.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\wavenet.h" />
@@ -392,6 +397,7 @@
     <ClCompile Include="..\..\AudioDSPTools\dsp\wav.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\activations.cpp" />
+    <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\conv1d.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\convnet.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\dsp.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
@@ -403,6 +409,7 @@
     </ClCompile>
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\get_dsp.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\lstm.cpp" />
+    <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\ring_buffer.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\util.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\wavenet.cpp" />
     <ClCompile Include="..\ToneStack.cpp" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-iOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-iOS.xcodeproj/project.pbxproj
@@ -52,6 +52,13 @@
 		4FBDC96329FFF143004FF203 /* activations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBDC94A29FFF143004FF203 /* activations.cpp */; };
 		4FBDC96429FFF143004FF203 /* wavenet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBDC94B29FFF143004FF203 /* wavenet.cpp */; };
 		4FBDC96529FFF143004FF203 /* get_dsp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBDC94C29FFF143004FF203 /* get_dsp.cpp */; };
+		4FBDC97729FFF143004FF203 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBDC97029FFF143004FF203 /* conv1d.cpp */; };
+		4FBDC97829FFF143004FF203 /* conv1d.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBDC97129FFF143004FF203 /* conv1d.h */; };
+		4FBDC97929FFF143004FF203 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBDC97229FFF143004FF203 /* ring_buffer.cpp */; };
+		4FBDC97A29FFF143004FF203 /* ring_buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBDC97329FFF143004FF203 /* ring_buffer.h */; };
+		4FBDC97B29FFF143004FF203 /* film.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBDC97429FFF143004FF203 /* film.h */; };
+		4FBDC97C29FFF143004FF203 /* gating_activations.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBDC97529FFF143004FF203 /* gating_activations.h */; };
+		4FBDC97D29FFF143004FF203 /* registry.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBDC97629FFF143004FF203 /* registry.h */; };
 		4FC69835293BA47F0076EC33 /* NeuralAmpModelerAU.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FC6982F293BA47F0076EC33 /* NeuralAmpModelerAU.framework */; };
 		4FC69836293BA47F0076EC33 /* NeuralAmpModelerAU.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4FC6982F293BA47F0076EC33 /* NeuralAmpModelerAU.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4FC6983A293BA4F10076EC33 /* NeuralAmpModelerAU.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FA61F7B22E89A5900A92C58 /* NeuralAmpModelerAU.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -282,6 +289,13 @@
 		4FBDC94429FFF143004FF203 /* convnet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convnet.cpp; sourceTree = "<group>"; };
 		4FBDC94529FFF143004FF203 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wavenet.h; sourceTree = "<group>"; };
 		4FBDC94629FFF143004FF203 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lstm.cpp; sourceTree = "<group>"; };
+		4FBDC97029FFF143004FF203 /* conv1d.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = conv1d.cpp; sourceTree = "<group>"; };
+		4FBDC97129FFF143004FF203 /* conv1d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv1d.h; sourceTree = "<group>"; };
+		4FBDC97229FFF143004FF203 /* ring_buffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ring_buffer.cpp; sourceTree = "<group>"; };
+		4FBDC97329FFF143004FF203 /* ring_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ring_buffer.h; sourceTree = "<group>"; };
+		4FBDC97429FFF143004FF203 /* film.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = film.h; sourceTree = "<group>"; };
+		4FBDC97529FFF143004FF203 /* gating_activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gating_activations.h; sourceTree = "<group>"; };
+		4FBDC97629FFF143004FF203 /* registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = registry.h; sourceTree = "<group>"; };
 		4FBDC94729FFF143004FF203 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
 		4FBDC94829FFF143004FF203 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dsp.h; sourceTree = "<group>"; };
 		4FBDC94929FFF143004FF203 /* activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activations.h; sourceTree = "<group>"; };
@@ -672,6 +686,13 @@
 				4FBDC94029FFF143004FF203 /* version.h */,
 				4FBDC94B29FFF143004FF203 /* wavenet.cpp */,
 				4FBDC94529FFF143004FF203 /* wavenet.h */,
+				4FBDC97029FFF143004FF203 /* conv1d.cpp */,
+				4FBDC97129FFF143004FF203 /* conv1d.h */,
+				4FBDC97229FFF143004FF203 /* ring_buffer.cpp */,
+				4FBDC97329FFF143004FF203 /* ring_buffer.h */,
+				4FBDC97429FFF143004FF203 /* film.h */,
+				4FBDC97529FFF143004FF203 /* gating_activations.h */,
+				4FBDC97629FFF143004FF203 /* registry.h */,
 			);
 			name = NAM;
 			path = ../../NeuralAmpModelerCore/NAM;
@@ -833,6 +854,11 @@
 				4FC6983A293BA4F10076EC33 /* NeuralAmpModelerAU.h in Headers */,
 				4FBDC95629FFF143004FF203 /* dsp.h in Headers */,
 				4FBDC95E29FFF143004FF203 /* wavenet.h in Headers */,
+				4FBDC97829FFF143004FF203 /* conv1d.h in Headers */,
+				4FBDC97A29FFF143004FF203 /* ring_buffer.h in Headers */,
+				4FBDC97B29FFF143004FF203 /* film.h in Headers */,
+				4FBDC97C29FFF143004FF203 /* gating_activations.h in Headers */,
+				4FBDC97D29FFF143004FF203 /* registry.h in Headers */,
 				4FC6983B293BA5020076EC33 /* IPlugAUAudioUnit.h in Headers */,
 				AA7C860B2B43A42F00B5FB3A /* ResamplingContainer.h in Headers */,
 				AA341E2B2B9E5A650069C260 /* ToneStack.h in Headers */,
@@ -1059,6 +1085,8 @@
 				4FBDC95829FFF143004FF203 /* util.cpp in Sources */,
 				4FC69849293BA5F90076EC33 /* ITextEntryControl.cpp in Sources */,
 				4FBDC96429FFF143004FF203 /* wavenet.cpp in Sources */,
+				4FBDC97729FFF143004FF203 /* conv1d.cpp in Sources */,
+				4FBDC97929FFF143004FF203 /* ring_buffer.cpp in Sources */,
 				4FC6984C293BA6010076EC33 /* IGraphicsCoreText.mm in Sources */,
 				4FC6984F293BA6420076EC33 /* IControl.cpp in Sources */,
 				4FC69848293BA5F90076EC33 /* IControls.cpp in Sources */,

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
@@ -137,6 +137,26 @@
 		4F2FB19C2A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
 		4F2FB19D2A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
 		4F2FB19E2A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
+		4F2FB1CE2A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1CF2A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D02A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D12A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D22A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D32A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D42A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D52A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D62A0047430027AB66 /* conv1d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1562A0047420027AB67 /* conv1d.cpp */; };
+		4F2FB1D72A0047430027AB66 /* conv1d.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2FB1572A0047420027AB67 /* conv1d.h */; };
+		4F2FB1D82A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1D92A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1DA2A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1DB2A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1DC2A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1DD2A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1DE2A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1DF2A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1E02A0047430027AB66 /* ring_buffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB1582A0047420027AB67 /* ring_buffer.cpp */; };
+		4F2FB1E12A0047430027AB66 /* ring_buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2FB1592A0047420027AB67 /* ring_buffer.h */; };
 		4F2FB19F2A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
 		4F2FB1A02A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
 		4F2FB1A12A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
@@ -668,6 +688,10 @@
 		4F2FB1492A0047420027AB66 /* convnet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = convnet.h; sourceTree = "<group>"; };
 		4F2FB14A2A0047420027AB66 /* lstm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstm.h; sourceTree = "<group>"; };
 		4F2FB14B2A0047420027AB66 /* convnet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convnet.cpp; sourceTree = "<group>"; };
+		4F2FB1562A0047420027AB67 /* conv1d.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = conv1d.cpp; sourceTree = "<group>"; };
+		4F2FB1572A0047420027AB67 /* conv1d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv1d.h; sourceTree = "<group>"; };
+		4F2FB1582A0047420027AB67 /* ring_buffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ring_buffer.cpp; sourceTree = "<group>"; };
+		4F2FB1592A0047420027AB67 /* ring_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ring_buffer.h; sourceTree = "<group>"; };
 		4F2FB14C2A0047420027AB66 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wavenet.h; sourceTree = "<group>"; };
 		4F2FB14D2A0047420027AB66 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lstm.cpp; sourceTree = "<group>"; };
 		4F2FB14E2A0047420027AB66 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
@@ -1294,7 +1318,11 @@
 				4F2FB1502A0047420027AB66 /* activations.h */,
 				4F2FB14B2A0047420027AB66 /* convnet.cpp */,
 				4F2FB1492A0047420027AB66 /* convnet.h */,
+				4F2FB1562A0047420027AB67 /* conv1d.cpp */,
+				4F2FB1572A0047420027AB67 /* conv1d.h */,
 				4F2FB1482A0047420027AB66 /* dsp.cpp */,
+				4F2FB1582A0047420027AB67 /* ring_buffer.cpp */,
+				4F2FB1592A0047420027AB67 /* ring_buffer.h */,
 				4F2FB14F2A0047420027AB66 /* dsp.h */,
 				4F2FB1532A0047420027AB66 /* get_dsp.cpp */,
 				AAB7BBB62CC4B8C6000B8B6E /* get_dsp.h */,
@@ -2635,6 +2663,8 @@
 				4F7C4958255DDFC400DF7588 /* IControls.cpp in Sources */,
 				4F2FB1562A0047420027AB66 /* RecursiveLinearFilter.cpp in Sources */,
 				4F2FB1BC2A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1CE2A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1D82A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F2FB1922A0047430027AB66 /* dsp.cpp in Sources */,
 				4F8D9707209EF5AC006E2A11 /* NeuralAmpModeler.cpp in Sources */,
 				4F7C495A255DDFC400DF7588 /* ITextEntryControl.cpp in Sources */,
@@ -2658,6 +2688,8 @@
 				4F2FB1A22A0047430027AB66 /* convnet.cpp in Sources */,
 				4F2FB1842A0047430027AB66 /* wav.cpp in Sources */,
 				4F2FB1C12A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1CF2A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1D92A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F2FB1662A0047430027AB66 /* dsp.cpp in Sources */,
 				4F2FB1AC2A0047430027AB66 /* lstm.cpp in Sources */,
 				4F2FB1B82A0047430027AB66 /* activations.cpp in Sources */,
@@ -2693,6 +2725,8 @@
 				4F2FB18A2A0047430027AB66 /* util.cpp in Sources */,
 				4F993F7423055C96000313AF /* IPlugProcessor.cpp in Sources */,
 				4F2FB1BE2A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D02A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1DA2A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F8C10E320BA2796006320CD /* IGraphicsEditorDelegate.cpp in Sources */,
 				4F6FD2B422675B6300FC59E6 /* IGraphicsCoreText.mm in Sources */,
 				4FDAC0ED207D76C600299363 /* IPlugTimer.cpp in Sources */,
@@ -2731,6 +2765,8 @@
 				4F3EE1CF231438D000004786 /* swell-menu.mm in Sources */,
 				4F2FB1992A0047430027AB66 /* dsp.cpp in Sources */,
 				4F2FB1C32A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D12A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1DB2A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F3EE1D0231438D000004786 /* IGraphicsMac_view.mm in Sources */,
 				4F7C496E255DDFCB00DF7588 /* IPopupMenuControl.cpp in Sources */,
 				4F3EE1D1231438D000004786 /* swell-appstub.mm in Sources */,
@@ -2795,6 +2831,8 @@
 				AA341E252B9E5A530069C260 /* ToneStack.cpp in Sources */,
 				4F78BE2522E7406D00AD537E /* IPlugPluginBase.cpp in Sources */,
 				4F2FB1C22A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D22A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1DC2A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F2FB1A32A0047430027AB66 /* convnet.cpp in Sources */,
 				4F78BE2622E7406D00AD537E /* IPlugAPIBase.cpp in Sources */,
 				4F2FB1AD2A0047430027AB66 /* lstm.cpp in Sources */,
@@ -2827,6 +2865,8 @@
 				4F2FB1802A0047430027AB66 /* wav.cpp in Sources */,
 				4F2FB1622A0047430027AB66 /* dsp.cpp in Sources */,
 				4F2FB1BD2A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D32A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1DD2A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F815919205D50EB00393585 /* memorystream.cpp in Sources */,
 				4F9828C1140A9EB700F3FCC1 /* IPlugParameter.cpp in Sources */,
 				4F81591A205D50EB00393585 /* pluginview.cpp in Sources */,
@@ -2905,6 +2945,8 @@
 				AA341E212B9E5A530069C260 /* ToneStack.cpp in Sources */,
 				4FB600231567CB0A0020189A /* IPlugParameter.cpp in Sources */,
 				4F2FB1BF2A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D42A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1DE2A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4F2FB1A02A0047430027AB66 /* convnet.cpp in Sources */,
 				4FB600261567CB0A0020189A /* AAX_Exports.cpp in Sources */,
 				4F2FB1AA2A0047430027AB66 /* lstm.cpp in Sources */,
@@ -2959,6 +3001,8 @@
 				4FD16D3E13B63595001D0217 /* swell-menu.mm in Sources */,
 				4F2FB1912A0047430027AB66 /* dsp.cpp in Sources */,
 				4F2FB1BB2A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D52A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1DF2A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4FB1F59120E4B011004157C8 /* IGraphicsMac_view.mm in Sources */,
 				4F7C4956255DDFC300DF7588 /* IPopupMenuControl.cpp in Sources */,
 				4F5C5F6B21BED08700E024A7 /* swell-appstub.mm in Sources */,
@@ -3032,6 +3076,8 @@
 				4F2FB1652A0047430027AB66 /* dsp.cpp in Sources */,
 				4F2FB1AB2A0047430027AB66 /* lstm.cpp in Sources */,
 				4F2FB1C02A0047430027AB66 /* wavenet.cpp in Sources */,
+				4F2FB1D62A0047430027AB66 /* conv1d.cpp in Sources */,
+				4F2FB1E02A0047430027AB66 /* ring_buffer.cpp in Sources */,
 				4FFBB91F20863B0E00DDD0E7 /* vstparameters.cpp in Sources */,
 				4FFBB92120863B0E00DDD0E7 /* vstcomponentbase.cpp in Sources */,
 				4FFBB92220863B0E00DDD0E7 /* IPlugVST3_Processor.cpp in Sources */,

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
@@ -164,6 +164,9 @@
 		4F2FB1A32A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
 		4F2FB1A42A0047430027AB66 /* convnet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14B2A0047420027AB66 /* convnet.cpp */; };
 		4F2FB1A52A0047430027AB66 /* wavenet.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2FB14C2A0047420027AB66 /* wavenet.h */; };
+		4F2FB1E22A0047430027AB68 /* film.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2FB15A2A0047420027AB68 /* film.h */; };
+		4F2FB1E32A0047430027AB68 /* gating_activations.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2FB15B2A0047420027AB68 /* gating_activations.h */; };
+		4F2FB1E42A0047430027AB68 /* registry.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F2FB15C2A0047420027AB68 /* registry.h */; };
 		4F2FB1A62A0047430027AB66 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14D2A0047420027AB66 /* lstm.cpp */; };
 		4F2FB1A72A0047430027AB66 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14D2A0047420027AB66 /* lstm.cpp */; };
 		4F2FB1A82A0047430027AB66 /* lstm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F2FB14D2A0047420027AB66 /* lstm.cpp */; };
@@ -693,6 +696,9 @@
 		4F2FB1582A0047420027AB67 /* ring_buffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ring_buffer.cpp; sourceTree = "<group>"; };
 		4F2FB1592A0047420027AB67 /* ring_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ring_buffer.h; sourceTree = "<group>"; };
 		4F2FB14C2A0047420027AB66 /* wavenet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wavenet.h; sourceTree = "<group>"; };
+		4F2FB15A2A0047420027AB68 /* film.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = film.h; sourceTree = "<group>"; };
+		4F2FB15B2A0047420027AB68 /* gating_activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gating_activations.h; sourceTree = "<group>"; };
+		4F2FB15C2A0047420027AB68 /* registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = registry.h; sourceTree = "<group>"; };
 		4F2FB14D2A0047420027AB66 /* lstm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lstm.cpp; sourceTree = "<group>"; };
 		4F2FB14E2A0047420027AB66 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
 		4F2FB14F2A0047420027AB66 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dsp.h; sourceTree = "<group>"; };
@@ -1333,6 +1339,9 @@
 				4F2FB1472A0047420027AB66 /* version.h */,
 				4F2FB1522A0047420027AB66 /* wavenet.cpp */,
 				4F2FB14C2A0047420027AB66 /* wavenet.h */,
+				4F2FB15A2A0047420027AB68 /* film.h */,
+				4F2FB15B2A0047420027AB68 /* gating_activations.h */,
+				4F2FB15C2A0047420027AB68 /* registry.h */,
 			);
 			name = NAM;
 			path = ../../NeuralAmpModelerCore/NAM;
@@ -2046,6 +2055,9 @@
 				4F2FB15F2A0047420027AB66 /* NoiseGate.h in Headers */,
 				4F2FB17D2A0047430027AB66 /* dsp.h in Headers */,
 				4F2FB1A52A0047430027AB66 /* wavenet.h in Headers */,
+				4F2FB1E22A0047430027AB68 /* film.h in Headers */,
+				4F2FB1E32A0047430027AB68 /* gating_activations.h in Headers */,
+				4F2FB1E42A0047430027AB68 /* registry.h in Headers */,
 				4F78BE1222E73DD900AD537E /* NeuralAmpModelerAU.h in Headers */,
 				4F2FB1542A0047420027AB66 /* Resample.h in Headers */,
 				4F2FB15E2A0047420027AB66 /* wav.h in Headers */,

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="PaceFixLogs" AssemblyFile="$(PACE_FUSION_HOME)PaceFusionUi2013.dll" />
   <ItemGroup Label="ProjectConfigurations">
@@ -344,10 +344,15 @@
     <ClInclude Include="..\NeuralAmpModeler.h" />
     <ClInclude Include="..\NeuralAmpModelerControls.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\activations.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\conv1d.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\convnet.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\dsp.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\film.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\gating_activations.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\get_dsp.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\lstm.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\registry.h" />
+    <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\ring_buffer.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\util.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\version.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\wavenet.h" />
@@ -420,6 +425,7 @@
     <ClCompile Include="..\..\AudioDSPTools\dsp\wav.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\activations.cpp" />
+    <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\conv1d.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\convnet.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\dsp.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(RelativeDir)</ObjectFileName>
@@ -431,6 +437,7 @@
     </ClCompile>
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\get_dsp.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\lstm.cpp" />
+    <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\ring_buffer.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\util.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\wavenet.cpp" />
     <ClCompile Include="..\ToneStack.cpp" />

--- a/common-mac.xcconfig
+++ b/common-mac.xcconfig
@@ -9,7 +9,7 @@ COMPILER = com.apple.compilers.llvm.clang.1_0
 // which osx sdk to compile against - defaults to latest SDK available
 BASE_SDK_MAC = macosx // latest SDK
 
-CLANG_CXX_LANGUAGE_STANDARD = c++17
+CLANG_CXX_LANGUAGE_STANDARD = c++20
 CLANG_CXX_LIBRARY = libc++
 
 CLANG_WARN_DOCUMENTATION_COMMENTS = NO

--- a/common-win.props
+++ b/common-win.props
@@ -78,7 +78,7 @@
       <PreprocessorDefinitions>$(ALL_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996;4250;4018;4267;4068;</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(WDL_PATH);$(IPLUG_PATH);$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ItemDefinitionGroup Condition=" '$(Platform)' == 'Win32' ">


### PR DESCRIPTION
This PR updates [NeuralAmpModelerCore](https://github.com/sdatkinson/NeuralAmpModelerCore) to v0.4.0.rc3.

Builders looking to upgrade from v0.3.0 to 0.4.0 can consult this to see what high-level changes to expect to do. The main one is the change to multi-input, multi-output models. The other is that there are new source & header files to track.

With this PR, the plugin should (fingers crossed) be able to support [Architecture A2](https://www.neuralampmodeler.com/post/architecture-a2) at full size; slimmability is still to come.