### PR TITLE
fix: only reset model on sample rate or buffer size change

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -613,14 +613,20 @@ void NeuralAmpModeler::_FallbackDSP(iplug::sample** inputs, iplug::sample** outp
 
 void NeuralAmpModeler::_ResetModelAndIR(const double sampleRate, const int maxBlockSize)
 {
+  auto needsReset = [&](const std::unique_ptr<ResamplingNAM>& m) {
+    return m->GetExpectedSampleRate() != sampleRate || m->GetMaxBufferSize() != maxBlockSize;
+  };
+
   // Model
   if (mStagedModel != nullptr)
   {
-    mStagedModel->Reset(sampleRate, maxBlockSize);
+    if (needsReset(mStagedModel))
+      mStagedModel->Reset(sampleRate, maxBlockSize);
   }
   else if (mModel != nullptr)
   {
-    mModel->Reset(sampleRate, maxBlockSize);
+    if (needsReset(mModel))
+      mModel->Reset(sampleRate, maxBlockSize);
   }
 
   // IR

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -164,6 +164,8 @@ public:
     mEncapsulated->ResetAndPrewarm(sampleRate, maxEncapsulatedBlockSize);
   };
 
+  int GetMaxBufferSize() const { return mMaxExternalBlockSize; };
+
   // So that we can let the world know if we're resampling (useful for debugging)
   double GetEncapsulatedSampleRate() const { return GetNAMSampleRate(mEncapsulated); };
 


### PR DESCRIPTION
**Thanks for making a Pull Request!**
Please fill out this template so that you can be sure that your PR does everything it needs to be accepted.

## Description
What does your PR do?
Include [Closing words](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) to link this PR to the Issue(s) that it relates to.

This PR changes `_ResetModelAndIR()` to only reset the model when the sample rate or buffer size changed. For me adding many NAM instances caused a hitch/delay on playback start which increased with the amount of instances. Changing the reset to only happen when sample rate/buffer size changed removed this delay completely.

Maybe there was a reason for this reset, I have no idea about audio processing really, I only know that this fixed the issue for me.

Feel free to make changes.

fixes https://github.com/sdatkinson/NeuralAmpModelerPlugin/issues/610

## PR Checklist
- [ ] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
Formatted using clang-format
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [x] Windows
  - [ ] macOS (can't test because of no machine)
- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [ ] Have you ensured that the plug-in unserializes correctly?
  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
- [ ] Does your PR add or remove any graphical assets? If yes, are they defined in [config.h](https://github.com/olilarkin/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/config.h) and added in the two required locations in [main.rc](https://github.com/olilarkin/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/resources/main.rc)?
  
