### PR TITLE
[BUGFIX] Fix standalone app's audio input

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "iPlug2"]
 	path = iPlug2
-	url = https://github.com/iPlug2/iPlug2
-	# url = https://github.com/sdatkinson/iPlug2.git
+	url = https://github.com/sdatkinson/iPlug2.git
 [submodule "eigen"]
 	path = eigen
 	url = https://gitlab.com/libeigen/eigen.git

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a cleaned up version of [the original iPlug2-based NAM plugin](https://g
 ## Rough edges
 
 ### Standalone I/O
-The I/O for the standalone doesn't inherit the stability of most plugin hosts (DAWs), so it's a bit sparser on features. The most common sharp edge is that **only input 1 is supported**. If you have a dual-input interface where the guitar goes in input 2 (e.g. Focusrite Solo), then you're going to need to either (A) use input 1 (and, perhaps, a DI box) or (B) use the plugin (VST3/AU) inside a plugin host.
+The I/O for the standalone doesn't inherit the stability of most plugin hosts (DAWs), so it's a bit sparser on features. For complex routing, the plugin (VST3/AU) inside a plugin host is still the most reliable option.
 
 ### Graphics backend
 If you're having trouble with NAM crashing before the GUI comes up, then you might have an unsupported graphics configuration. Usually, this is when you have a dedicated graphics card (like an nVIDIA GPU) and you're using the integrated (CPU) graphics on a Windows system. To fix this, Go to the control panel, pick NAM (or your DAW), and make sure that it uses your graphics card. (If you know more and can help fix this, please make an Issue and let me know more!)


### PR DESCRIPTION
## Description
* Allow choosing audio inputs other than the first one (Scarlett Solo can use its 1/4" input!)
* Support for single-input devices maintained.

Resolves #157. 
Resolves #209.

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [x] Windows
  - [x] macOS
- [N] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [N/A] Have you ensured that the plug-in unserializes correctly?
  - [N/A] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
- [N] Does your PR add or remove any graphical assets? If yes, are they defined in [config.h](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/config.h) and added in the two required locations in [main.rc](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/resources/main.rc)?

Additional checks:
* Works on macOS with Scarlett 2i2 both inputs and with the microphone input (single-input example)
* Works on Windows 11 with Scarlett 18i20 Gen 1 with inputs 1, 2, and 3.
  
