### PR TITLE
feat: add global CTRL keyboard shortcuts to file browser controls

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -309,6 +309,25 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
       pControl->SetMouseOverWhenDisabled(true);
     });
 
+    auto* modelBrowser =
+      static_cast<NAMFileBrowserControl*>(pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser));
+    auto* irBrowser =
+      static_cast<NAMFileBrowserControl*>(pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser));
+
+    pGraphics->SetKeyHandlerFunc([modelBrowser, irBrowser](const IKeyPress& key, bool isUp) -> bool {
+      if (isUp || !key.C || !modelBrowser || !irBrowser)
+        return false;
+      NAMFileBrowserControl* target = key.S ? irBrowser : modelBrowser;
+      switch (key.VK)
+      {
+        case kVK_O: target->LoadFile(); return true;
+        case kVK_LEFT: target->PrevFile(); return true;
+        case kVK_RIGHT: target->NextFile(); return true;
+        case kVK_BACK: target->ClearOrGet(); return true;
+        default: return false;
+      }
+    });
+
     // pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetMouseEventsWhenDisabled(false);
     // pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetMouseEventsWhenDisabled(false);
   };

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -304,67 +304,13 @@ public:
 
   void OnAttached() override
   {
-    auto prevFileFunc = [&](IControl* pCaller) {
-      const auto nItems = NItems();
-      if (nItems == 0)
-        return;
-      mSelectedItemIndex--;
+    auto prevFileFunc = [&](IControl* pCaller) { PrevFile(); };
 
-      if (mSelectedItemIndex < 0)
-        mSelectedItemIndex = nItems - 1;
+    auto nextFileFunc = [&](IControl* pCaller) { NextFile(); };
 
-      LoadFileAtCurrentIndex();
-    };
+    auto loadFileFunc = [&](IControl* pCaller) { LoadFile(); };
 
-    auto nextFileFunc = [&](IControl* pCaller) {
-      const auto nItems = NItems();
-      if (nItems == 0)
-        return;
-      mSelectedItemIndex++;
-
-      if (mSelectedItemIndex >= nItems)
-        mSelectedItemIndex = 0;
-
-      LoadFileAtCurrentIndex();
-    };
-
-    auto loadFileFunc = [&](IControl* pCaller) {
-      WDL_String fileName;
-      WDL_String path;
-      GetSelectedFileDirectory(path);
-#ifdef NAM_PICK_DIRECTORY
-      pCaller->GetUI()->PromptForDirectory(path, [&](const WDL_String& fileName, const WDL_String& path) {
-        if (path.GetLength())
-        {
-          ClearPathList();
-          AddPath(path.Get(), "");
-          SetupMenu();
-          SelectFirstFile();
-          LoadFileAtCurrentIndex();
-        }
-      });
-#else
-      pCaller->GetUI()->PromptForFile(
-        fileName, path, EFileAction::Open, mExtension.Get(), [&](const WDL_String& fileName, const WDL_String& path) {
-          if (fileName.GetLength())
-          {
-            ClearPathList();
-            AddPath(path.Get(), "");
-            SetupMenu();
-            SetSelectedFile(fileName.Get());
-            LoadFileAtCurrentIndex();
-          }
-        });
-#endif
-    };
-
-    auto clearFileFunc = [&](IControl* pCaller) {
-      pCaller->GetDelegate()->SendArbitraryMsgFromUI(mClearMsgTag);
-      mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
-      SetBrowserState(NAMBrowserState::Empty);
-      // FIXME disabling output mode...
-      //      pCaller->GetUI()->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(false);
-    };
+    auto clearFileFunc = [&](IControl* pCaller) { ClearOrGet(); };
 
     auto chooseFileFunc = [&, loadFileFunc](IControl* pCaller) {
       if (std::string_view(pCaller->As<IVButtonControl>()->GetLabelStr()) == mDefaultLabelStr.Get())
@@ -410,6 +356,77 @@ public:
 
     // initialize control visibility
     SetBrowserState(NAMBrowserState::Empty);
+  }
+
+  void LoadFile()
+  {
+    WDL_String fileName;
+    WDL_String path;
+    GetSelectedFileDirectory(path);
+#ifdef NAM_PICK_DIRECTORY
+    GetUI()->PromptForDirectory(path, [&](const WDL_String& fileName, const WDL_String& path) {
+      if (path.GetLength())
+      {
+        ClearPathList();
+        AddPath(path.Get(), "");
+        SetupMenu();
+        SelectFirstFile();
+        LoadFileAtCurrentIndex();
+      }
+    });
+#else
+    GetUI()->PromptForFile(
+      fileName, path, EFileAction::Open, mExtension.Get(),
+      [&](const WDL_String& fileName, const WDL_String& path) {
+        if (fileName.GetLength())
+        {
+          ClearPathList();
+          AddPath(path.Get(), "");
+          SetupMenu();
+          SetSelectedFile(fileName.Get());
+          LoadFileAtCurrentIndex();
+        }
+      });
+#endif
+  }
+
+  void PrevFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedItemIndex--;
+    if (mSelectedItemIndex < 0)
+      mSelectedItemIndex = nItems - 1;
+    LoadFileAtCurrentIndex();
+  }
+
+  void NextFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedItemIndex++;
+    if (mSelectedItemIndex >= nItems)
+      mSelectedItemIndex = 0;
+    LoadFileAtCurrentIndex();
+  }
+
+  void ClearOrGet()
+  {
+    if (mBrowserState == NAMBrowserState::Loaded)
+    {
+      GetDelegate()->SendArbitraryMsgFromUI(mClearMsgTag);
+      mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
+      SetBrowserState(NAMBrowserState::Empty);
+      // FIXME disabling output mode...
+      //      GetUI()->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(false);
+    }
+    else
+    {
+      WDL_String url(mGetButtonURL);
+      GetUI()->OpenURL(url.Get());
+    }
   }
 
   void LoadFileAtCurrentIndex()

--- a/docs/superpowers/plans/2026-06-01-keyboard-shortcuts.md
+++ b/docs/superpowers/plans/2026-06-01-keyboard-shortcuts.md
@@ -1,0 +1,291 @@
+# Keyboard Shortcuts for NAMFileBrowserControl Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add global CTRL-based keyboard shortcuts to the Model and IR file browser rows so all four button actions (load, previous, next, clear/get) can be triggered without using the mouse.
+
+**Architecture:** Extract the four action lambdas inside `NAMFileBrowserControl::OnAttached` into public methods, then register a global `SetKeyHandlerFunc` in `LayoutUI` that dispatches to those methods based on the pressed key and whether SHIFT is held (SHIFT = IR row, no SHIFT = Model row).
+
+**Tech Stack:** C++17, iPlug2 (`IDirBrowseControlBase`, `IKeyPress`, `kVK_*` constants from `IPlugConstants.h`), Windows Visual Studio / MSBuild.
+
+---
+
+## Files Modified
+
+- `NeuralAmpModeler/NeuralAmpModelerControls.h` — Add four public methods to `NAMFileBrowserControl`; simplify the four action lambdas in `OnAttached` to call those methods.
+- `NeuralAmpModeler/NeuralAmpModeler.cpp` — Register `SetKeyHandlerFunc` at the end of `LayoutUI`.
+
+---
+
+## Task 1: Add public action methods to `NAMFileBrowserControl`
+
+**Files:**
+- Modify: `NeuralAmpModeler/NeuralAmpModelerControls.h:305-413`
+
+There is no automated test suite for this project. Verification is a successful build followed by manual testing in a plugin host.
+
+- [ ] **Step 1: Add four public methods above the existing `private:` section**
+
+In [NeuralAmpModelerControls.h](NeuralAmpModeler/NeuralAmpModelerControls.h), find the `private:` section that begins at line 458. Insert the following four public methods immediately above it (between the closing `}` of `OnAttached` and `private:`):
+
+```cpp
+  void LoadFile()
+  {
+    WDL_String fileName;
+    WDL_String path;
+    GetSelectedFileDirectory(path);
+#ifdef NAM_PICK_DIRECTORY
+    GetUI()->PromptForDirectory(path, [&](const WDL_String& fileName, const WDL_String& path) {
+      if (path.GetLength())
+      {
+        ClearPathList();
+        AddPath(path.Get(), "");
+        SetupMenu();
+        SelectFirstFile();
+        LoadFileAtCurrentIndex();
+      }
+    });
+#else
+    GetUI()->PromptForFile(
+      fileName, path, EFileAction::Open, mExtension.Get(),
+      [&](const WDL_String& fileName, const WDL_String& path) {
+        if (fileName.GetLength())
+        {
+          ClearPathList();
+          AddPath(path.Get(), "");
+          SetupMenu();
+          SetSelectedFile(fileName.Get());
+          LoadFileAtCurrentIndex();
+        }
+      });
+#endif
+  }
+
+  void PrevFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedItemIndex--;
+    if (mSelectedItemIndex < 0)
+      mSelectedItemIndex = nItems - 1;
+    LoadFileAtCurrentIndex();
+  }
+
+  void NextFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedItemIndex++;
+    if (mSelectedItemIndex >= nItems)
+      mSelectedItemIndex = 0;
+    LoadFileAtCurrentIndex();
+  }
+
+  void ClearOrGet()
+  {
+    if (mBrowserState == NAMBrowserState::Loaded)
+    {
+      GetDelegate()->SendArbitraryMsgFromUI(mClearMsgTag);
+      mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
+      SetBrowserState(NAMBrowserState::Empty);
+    }
+    else
+    {
+      WDL_String url(mGetButtonURL);
+      GetUI()->OpenURL(url.Get());
+    }
+  }
+```
+
+- [ ] **Step 2: Simplify the four action lambdas in `OnAttached`**
+
+In the same file, find `OnAttached` (around line 305). Replace the bodies of the four lambdas as follows. Each lambda's body becomes a single call to the corresponding public method.
+
+Replace:
+```cpp
+    auto prevFileFunc = [&](IControl* pCaller) {
+      const auto nItems = NItems();
+      if (nItems == 0)
+        return;
+      mSelectedItemIndex--;
+
+      if (mSelectedItemIndex < 0)
+        mSelectedItemIndex = nItems - 1;
+
+      LoadFileAtCurrentIndex();
+    };
+
+    auto nextFileFunc = [&](IControl* pCaller) {
+      const auto nItems = NItems();
+      if (nItems == 0)
+        return;
+      mSelectedItemIndex++;
+
+      if (mSelectedItemIndex >= nItems)
+        mSelectedItemIndex = 0;
+
+      LoadFileAtCurrentIndex();
+    };
+
+    auto loadFileFunc = [&](IControl* pCaller) {
+      WDL_String fileName;
+      WDL_String path;
+      GetSelectedFileDirectory(path);
+#ifdef NAM_PICK_DIRECTORY
+      pCaller->GetUI()->PromptForDirectory(path, [&](const WDL_String& fileName, const WDL_String& path) {
+        if (path.GetLength())
+        {
+          ClearPathList();
+          AddPath(path.Get(), "");
+          SetupMenu();
+          SelectFirstFile();
+          LoadFileAtCurrentIndex();
+        }
+      });
+#else
+      pCaller->GetUI()->PromptForFile(
+        fileName, path, EFileAction::Open, mExtension.Get(), [&](const WDL_String& fileName, const WDL_String& path) {
+          if (fileName.GetLength())
+          {
+            ClearPathList();
+            AddPath(path.Get(), "");
+            SetupMenu();
+            SetSelectedFile(fileName.Get());
+            LoadFileAtCurrentIndex();
+          }
+        });
+#endif
+    };
+
+    auto clearFileFunc = [&](IControl* pCaller) {
+      pCaller->GetDelegate()->SendArbitraryMsgFromUI(mClearMsgTag);
+      mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
+      SetBrowserState(NAMBrowserState::Empty);
+      // FIXME disabling output mode...
+      //      pCaller->GetUI()->GetControlWithTag(kCtrlTagOutputMode)->SetDisabled(false);
+    };
+```
+
+With:
+```cpp
+    auto prevFileFunc = [&](IControl* pCaller) { PrevFile(); };
+
+    auto nextFileFunc = [&](IControl* pCaller) { NextFile(); };
+
+    auto loadFileFunc = [&](IControl* pCaller) { LoadFile(); };
+
+    auto clearFileFunc = [&](IControl* pCaller) { ClearOrGet(); };
+```
+
+- [ ] **Step 3: Build to verify no compile errors**
+
+From a Developer Command Prompt (or PowerShell with MSBuild on PATH):
+```
+msbuild NeuralAmpModeler\NeuralAmpModeler.sln /p:Configuration=Debug /p:Platform=x64 /t:Build /m
+```
+
+Expected: `Build succeeded.` with 0 errors. Warnings are OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add NeuralAmpModeler/NeuralAmpModelerControls.h
+git commit -m "refactor: extract NAMFileBrowserControl actions into public methods"
+```
+
+---
+
+## Task 2: Register global keyboard shortcut handler in `LayoutUI`
+
+**Files:**
+- Modify: `NeuralAmpModeler/NeuralAmpModeler.cpp:307-314`
+
+- [ ] **Step 1: Add the key handler at the end of `LayoutUI`**
+
+In [NeuralAmpModeler.cpp](NeuralAmpModeler/NeuralAmpModeler.cpp), find the `ForAllControlsFunc` block near the end of `LayoutUI` (around line 307). Insert the key handler immediately after it, before the closing `};` of the `LayoutUI` lambda:
+
+```cpp
+    auto* modelBrowser =
+      static_cast<NAMFileBrowserControl*>(pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser));
+    auto* irBrowser =
+      static_cast<NAMFileBrowserControl*>(pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser));
+
+    pGraphics->SetKeyHandlerFunc([modelBrowser, irBrowser](const IKeyPress& key, bool isUp) -> bool {
+      if (isUp || !key.C)
+        return false;
+      NAMFileBrowserControl* target = key.S ? irBrowser : modelBrowser;
+      switch (key.VK)
+      {
+        case kVK_O: target->LoadFile(); return true;
+        case kVK_LEFT: target->PrevFile(); return true;
+        case kVK_RIGHT: target->NextFile(); return true;
+        case kVK_BACK: target->ClearOrGet(); return true;
+        default: return false;
+      }
+    });
+```
+
+After this insertion the end of `LayoutUI` should look like:
+
+```cpp
+    pGraphics->ForAllControlsFunc([](IControl* pControl) {
+      pControl->SetMouseEventsWhenDisabled(true);
+      pControl->SetMouseOverWhenDisabled(true);
+    });
+
+    auto* modelBrowser =
+      static_cast<NAMFileBrowserControl*>(pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser));
+    auto* irBrowser =
+      static_cast<NAMFileBrowserControl*>(pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser));
+
+    pGraphics->SetKeyHandlerFunc([modelBrowser, irBrowser](const IKeyPress& key, bool isUp) -> bool {
+      if (isUp || !key.C)
+        return false;
+      NAMFileBrowserControl* target = key.S ? irBrowser : modelBrowser;
+      switch (key.VK)
+      {
+        case kVK_O: target->LoadFile(); return true;
+        case kVK_LEFT: target->PrevFile(); return true;
+        case kVK_RIGHT: target->NextFile(); return true;
+        case kVK_BACK: target->ClearOrGet(); return true;
+        default: return false;
+      }
+    });
+  };
+}
+```
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```
+msbuild NeuralAmpModeler\NeuralAmpModeler.sln /p:Configuration=Debug /p:Platform=x64 /t:Build /m
+```
+
+Expected: `Build succeeded.` with 0 errors.
+
+- [ ] **Step 3: Manual smoke test in a host**
+
+Load the built VST3/plugin in a DAW or the iPlug2 standalone app. With the plugin window focused:
+
+| Action | Keys | Expected result |
+|--------|------|-----------------|
+| Load model file dialog | CTRL+O | File open dialog appears for `.nam` files |
+| Next model | CTRL+→ | Plugin loads the next `.nam` file in the directory |
+| Previous model | CTRL+← | Plugin loads the previous `.nam` file |
+| Clear model (when loaded) | CTRL+⌫ | Model is cleared; label resets to "Select model..." |
+| Get NAM models URL (when empty) | CTRL+⌫ | System browser opens to NAM models page |
+| Load IR file dialog | CTRL+SHIFT+O | File open dialog appears for `.wav` files |
+| Next IR | CTRL+SHIFT+→ | Plugin loads the next `.wav` file |
+| Previous IR | CTRL+SHIFT+← | Plugin loads the previous `.wav` file |
+| Clear IR (when loaded) | CTRL+SHIFT+⌫ | IR is cleared; label resets to "Select IR..." |
+| Unrelated keys (e.g. CTRL+Z) | CTRL+Z | Nothing happens in the plugin; host may handle it |
+| Settings panel Escape | ESC (while panel open) | Panel closes; model/IR shortcuts still work after |
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add NeuralAmpModeler/NeuralAmpModeler.cpp
+git commit -m "feat: add global CTRL keyboard shortcuts to file browser controls"
+```

--- a/docs/superpowers/specs/2026-06-01-keyboard-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-06-01-keyboard-shortcuts-design.md
@@ -1,0 +1,76 @@
+# Design: Keyboard Shortcuts for NAMFileBrowserControl
+
+**Date:** 2026-06-01  
+**Status:** Approved
+
+## Overview
+
+Add global CTRL-based keyboard shortcuts to the two `NAMFileBrowserControl` rows (Model and IR) so that all four button actions — load, previous, next, and clear/get — can be triggered from the keyboard without clicking.
+
+## Key Mapping
+
+| Action | Model row | IR row |
+|--------|-----------|--------|
+| Load (open file dialog) | CTRL+O | CTRL+SHIFT+O |
+| Previous file | CTRL+← | CTRL+SHIFT+← |
+| Next file | CTRL+→ | CTRL+SHIFT+→ |
+| Clear (loaded) / Get URL (empty) | CTRL+⌫ | CTRL+SHIFT+⌫ |
+
+- CTRL = `key.C` in iPlug2's `IKeyPress`
+- SHIFT = `key.S`; its presence selects the IR row vs the Model row
+- ⌫ = Backspace (`kVK_BACK`, `0x08`)
+- Shortcuts fire on key-down only (`isUp == false`)
+
+## Architecture
+
+The feature touches exactly two files:
+
+### 1. `NeuralAmpModeler/NeuralAmpModelerControls.h` — `NAMFileBrowserControl`
+
+Extract the logic currently inside the four `OnAttached` lambdas into four public methods:
+
+- `LoadFile()` — triggers the file dialog (wraps `loadFileFunc` logic)
+- `PrevFile()` — navigates to the previous file (wraps `prevFileFunc` logic)
+- `NextFile()` — navigates to the next file (wraps `nextFileFunc` logic)
+- `ClearOrGet()` — clears the loaded file if one is loaded, or opens the Get URL if in the empty state (wraps `clearFileFunc` / Get URL open logic)
+
+The lambdas in `OnAttached` become one-line calls to these methods. No logic is duplicated.
+
+`ClearOrGet()` checks `mBrowserState` to determine which action to take. Opening the URL requires `GetUI()->OpenURL(...)`, which is available inside the control.
+
+### 2. `NeuralAmpModeler/NeuralAmpModeler.cpp` — `LayoutUI`
+
+After both browser controls are attached and tagged, register a global key handler:
+
+```cpp
+auto* modelBrowser = static_cast<NAMFileBrowserControl*>(
+    pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser));
+auto* irBrowser = static_cast<NAMFileBrowserControl*>(
+    pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser));
+
+pGraphics->SetKeyHandlerFunc([modelBrowser, irBrowser](const IKeyPress& key, bool isUp) -> bool {
+    if (isUp || !key.C) return false;
+    NAMFileBrowserControl* target = key.S ? irBrowser : modelBrowser;
+    switch (key.VK) {
+        case kVK_O:     target->LoadFile();    return true;
+        case kVK_LEFT:  target->PrevFile();    return true;
+        case kVK_RIGHT: target->NextFile();    return true;
+        case kVK_BACK:  target->ClearOrGet(); return true;
+        default:        return false;
+    }
+});
+```
+
+The handler returns `false` for any key it does not claim, leaving all other global key events unaffected.
+
+## Edge Cases
+
+- **No directory / no files** — `PrevFile` and `NextFile` already guard `NItems() == 0` and are no-ops; no change needed.
+- **Settings panel open** — the settings panel overrides `OnKeyDown` for `Escape`. iPlug2's global `SetKeyHandlerFunc` only fires when no control under the cursor claimed the event, so there is no conflict.
+- **`ClearOrGet` in Get state** — opens the NAM/IR URL in the system browser, same as clicking the globe button. Uses `GetUI()->OpenURL(...)`.
+
+## Out of Scope
+
+- No visual shortcut hints or on-screen overlay
+- No new plugin parameters or preset state
+- No changes to the visual appearance of the controls


### PR DESCRIPTION
**Thanks for making a Pull Request!**

## Description

Adds global keyboard shortcuts to the Model and IR file browser rows, so all four button actions can be triggered from the keyboard without mouse interaction.

| Action | Model row | IR row |
|--------|-----------|--------|
| Load (open file dialog) | CTRL+O / CMD+O | CTRL+SHIFT+O / CMD+SHIFT+O |
| Previous file | CTRL+← / CMD+← | CTRL+SHIFT+← / CMD+SHIFT+← |
| Next file | CTRL+→ / CMD+→ | CTRL+SHIFT+→ / CMD+SHIFT+→ |
| Clear (loaded) / Get URL (empty) | CTRL+⌫ / CMD+⌫ | CTRL+SHIFT+⌫ / CMD+SHIFT+⌫ |

iPlug2's `IKeyPress.C` field maps to CTRL on Windows and CMD on Mac automatically, so shortcuts follow correct platform conventions on both OSes with no conditional code.

### Architecture

**`NAMFileBrowserControl` (`NeuralAmpModelerControls.h`)**

The four action lambdas previously defined inline in `OnAttached` (`prevFileFunc`, `nextFileFunc`, `loadFileFunc`, `clearFileFunc`) have been extracted into four public methods:

- `LoadFile()` — opens the platform file/directory dialog, then loads the selected file into the directory list and calls `LoadFileAtCurrentIndex()`. Uses `GetUI()` in place of `pCaller->GetUI()` — equivalent at runtime since both resolve to the same `IGraphics` instance.
- `PrevFile()` — decrements `mSelectedItemIndex` with wraparound and calls `LoadFileAtCurrentIndex()`.
- `NextFile()` — increments `mSelectedItemIndex` with wraparound and calls `LoadFileAtCurrentIndex()`.
- `ClearOrGet()` — checks `mBrowserState`. If `Loaded`: sends the clear delegate message, resets the filename label, and transitions state to `Empty`. If `Empty`: opens `mGetButtonURL` in the system browser via `GetUI()->OpenURL()`. This unification is necessary because a keyboard shortcut cannot observe which of the two mutually-exclusive buttons (`mClearButton` / `mGetButton`) is currently visible; the state check makes the dispatch explicit.

The `OnAttached` lambdas become single-line delegates to these methods. The `chooseFileFunc` lambda (context menu / load on the filename button) is unchanged, as it has no keyboard equivalent.

**`NeuralAmpModeler.cpp` — `LayoutUI`**

A `SetKeyHandlerFunc` call is registered at the end of `LayoutUI`, after all controls are attached. This is iPlug2's intended extension point for global key handling: the handler fires as a fallback for any key event not already claimed by the control under the mouse cursor, giving true global coverage regardless of mouse position.

```cpp
auto* modelBrowser = static_cast<NAMFileBrowserControl*>(
    pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser));
auto* irBrowser = static_cast<NAMFileBrowserControl*>(
    pGraphics->GetControlWithTag(kCtrlTagIRFileBrowser));

pGraphics->SetKeyHandlerFunc([modelBrowser, irBrowser](const IKeyPress& key, bool isUp) -> bool {
  if (isUp || !key.C || !modelBrowser || !irBrowser)
    return false;
  NAMFileBrowserControl* target = key.S ? irBrowser : modelBrowser;
  switch (key.VK)
  {
    case kVK_O:     target->LoadFile();    return true;
    case kVK_LEFT:  target->PrevFile();    return true;
    case kVK_RIGHT: target->NextFile();    return true;
    case kVK_BACK:  target->ClearOrGet(); return true;
    default:        return false;
  }
});
```

Key design decisions:
- `isUp` guard ensures shortcuts fire on key-down only.
- `!key.C` guard means the handler claims nothing unless CTRL/CMD is held, leaving all other host and plugin key events unaffected.
- Null guards on `modelBrowser` and `irBrowser` protect against future renames of control tags.
- `key.S` (SHIFT) selects the IR row; its absence selects the Model row. No new key sets are needed for the second row.
- The handler returns `false` for any key it does not claim, so host DAW shortcuts for unhandled keys are preserved.

The `SetKeyHandlerFunc` pointer is captured after both browser controls are attached, so the raw pointers are valid for the lifetime of the open plugin window. `LayoutUI` is called once per UI session (resize is non-layout), so there is no re-registration concern.

## PR Checklist
- [ ] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [ ] macOS
- [x] Does your PR add, remove, or rename any plugin parameters? **No.**
- [x] Does your PR add or remove any graphical assets? **No.**