### PR TITLE
Add `,` and `.` keyboard shortcuts to switch models

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -309,6 +309,26 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
       pControl->SetMouseOverWhenDisabled(true);
     });
 
+    pGraphics->SetKeyHandlerFunc([pGraphics](const IKeyPress& key, bool isUp) {
+      if (isUp)
+        return false;
+      auto* pBrowser = pGraphics->GetControlWithTag(kCtrlTagModelFileBrowser);
+      if (pBrowser == nullptr)
+        return false;
+      auto* pModelBrowser = static_cast<NAMFileBrowserControl*>(pBrowser);
+      if (key.utf8[0] == ',')
+      {
+        pModelBrowser->SelectPreviousFile();
+        return true;
+      }
+      if (key.utf8[0] == '.')
+      {
+        pModelBrowser->SelectNextFile();
+        return true;
+      }
+      return false;
+    });
+
     // pGraphics->GetControlWithTag(kCtrlTagOutNorm)->SetMouseEventsWhenDisabled(false);
     // pGraphics->GetControlWithTag(kCtrlTagCalibrateInput)->SetMouseEventsWhenDisabled(false);
   };

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -302,31 +302,36 @@ public:
     }
   }
 
+  void SelectPreviousFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedItemIndex--;
+
+    if (mSelectedItemIndex < 0)
+      mSelectedItemIndex = nItems - 1;
+
+    LoadFileAtCurrentIndex();
+  }
+
+  void SelectNextFile()
+  {
+    const auto nItems = NItems();
+    if (nItems == 0)
+      return;
+    mSelectedItemIndex++;
+
+    if (mSelectedItemIndex >= nItems)
+      mSelectedItemIndex = 0;
+
+    LoadFileAtCurrentIndex();
+  }
+
   void OnAttached() override
   {
-    auto prevFileFunc = [&](IControl* pCaller) {
-      const auto nItems = NItems();
-      if (nItems == 0)
-        return;
-      mSelectedItemIndex--;
-
-      if (mSelectedItemIndex < 0)
-        mSelectedItemIndex = nItems - 1;
-
-      LoadFileAtCurrentIndex();
-    };
-
-    auto nextFileFunc = [&](IControl* pCaller) {
-      const auto nItems = NItems();
-      if (nItems == 0)
-        return;
-      mSelectedItemIndex++;
-
-      if (mSelectedItemIndex >= nItems)
-        mSelectedItemIndex = 0;
-
-      LoadFileAtCurrentIndex();
-    };
+    auto prevFileFunc = [&](IControl* pCaller) { SelectPreviousFile(); };
+    auto nextFileFunc = [&](IControl* pCaller) { SelectNextFile(); };
 
     auto loadFileFunc = [&](IControl* pCaller) {
       WDL_String fileName;


### PR DESCRIPTION
This PR adds `,` and `.` keyboard shortcuts for changing the current model in the model list. You click in the VST window to give focus to the VST, then `,` or `.` to change the model, the model loading wraps end to start like the UI arrows. There are no other shortcuts for loading/clearing and such, I was only interested in changing models quickly without reaching for the mouse.

The code was written using Claude.

## Description
(by Claude)
Exposes prev/next file navigation on NAMFileBrowserControl as public methods and installs a plugin-level key handler that maps kVK_LEFT and kVK_RIGHT (no modifiers) to the model browser's prev/next actions. Requires the plugin window to have keyboard focus. Text entries and other controls that consume the key still take precedence.

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [x] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [x] Windows
  - [ ] macOS
- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [ ] Have you ensured that the plug-in unserializes correctly?
  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
- [ ] Does your PR add or remove any graphical assets? If yes, are they defined in [config.h](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/config.h) and added in the two required locations in [main.rc](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/resources/main.rc)?
  
