### PR TITLE
[FEATURE] Preset Manager

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -2,6 +2,8 @@
 #include <cmath> // pow
 #include <filesystem>
 #include <iostream>
+#include <map>
+#include <optional>
 #include <utility>
 
 #include "Colors.h"
@@ -75,10 +77,24 @@ const std::string kInputCalibrationLevelParamName = "InputCalibrationLevel";
 const double kDefaultInputCalibrationLevel = 12.0;
 
 
+namespace
+{
+std::string GetPresetsBasePath()
+{
+  WDL_String appSupportPath;
+  AppSupportPath(appSupportPath, false);
+  return std::string(appSupportPath.Get()) + "/NeuralAmpModeler";
+}
+} // namespace
+
 NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
+, mPresetManager(GetPresetsBasePath())
 {
   _InitToneStack();
+  // Silently proceeds with an empty in-memory preset list on failure (e.g. corrupt
+  // presets.json); the user finds out when Save()/Add() fail on next use.
+  mPresetManager.Load();
   nam::activations::Activation::enable_fast_tanh();
   GetParam(kInputLevel)->InitGain("Input", 0.0, -20.0, 20.0, 0.1);
   GetParam(kToneBass)->InitDouble("Bass", 5.0, 0.0, 10.0, 0.1);
@@ -180,6 +196,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
 
     // Misc Areas
     const auto settingsButtonArea = CornerButtonArea(b);
+    // Preset menu button (issue #252), top-left corner.
+    const auto presetButtonArea = mainArea.GetFromTLHC(56.0f, 18.0f).GetVShifted(16.0f).GetHShifted(15.0f);
 
     // Model loader button
     auto loadModelCompletionHandler = [&](const WDL_String& fileName, const WDL_String& path) {
@@ -290,6 +308,13 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
         pGraphics->GetControlWithTag(kCtrlTagSettingsBox)->As<NAMSettingsPageControl>()->HideAnimated(false);
       },
       gearSVG));
+
+    // Presets (issue #252): click builds the menu from the current preset names and shows it.
+    // Black fill, no vector frame (DrawFrame(false) skips the border draw regardless of kFR).
+    const auto presetButtonStyle = style.WithColor(EVColor::kFG, COLOR_BLACK).WithDrawFrame(false);
+    auto showPresetMenuFunc = [&](IControl* pCaller) { pCaller->As<NAMPresetControl>()->ShowMenu(GetPresetNames()); };
+    pGraphics->AttachControl(new NAMPresetControl(presetButtonArea, presetButtonStyle), kCtrlTagPresetControl)
+      ->SetAnimationEndActionFunction(showPresetMenuFunc);
 
     pGraphics
       ->AttachControl(new NAMSettingsPageControl(b, backgroundBitmap, inputLevelBackgroundBitmap, switchHandleBitmap,
@@ -504,6 +529,10 @@ void NeuralAmpModeler::OnUIOpen()
   {
     _UpdateControlsFromModel();
   }
+
+  if (mCurrentPresetName.GetLength())
+    SendControlMsgFromDelegate(
+      kCtrlTagPresetControl, kMsgTagPresetNameChanged, mCurrentPresetName.GetLength(), mCurrentPresetName.Get());
 }
 
 void NeuralAmpModeler::OnParamChange(int paramIdx)
@@ -570,6 +599,75 @@ bool NeuralAmpModeler::OnMessage(int msgTag, int ctrlTag, int dataSize, const vo
         });
       }
 
+      return true;
+    }
+    case kMsgTagLoadPreset:
+    {
+      const std::string name(reinterpret_cast<const char*>(pData));
+      const std::optional<nam_presets::PresetData> preset = mPresetManager.Get(name);
+      if (preset)
+      {
+        _ApplyPreset(*preset);
+        _SetCurrentPresetName(name);
+      }
+      else
+        _ShowMessageBox(GetUI(), ("Preset \"" + name + "\" not found.").c_str(), "Failed to load preset!", kMB_OK);
+      return true;
+    }
+    case kMsgTagSavePreset:
+    {
+      const std::string name(reinterpret_cast<const char*>(pData));
+      const nam_presets::PresetData preset = _CollectCurrentState(name);
+      // Set only when overwriting: the preset being replaced, kept so a failed disk
+      // write can put it back (see the rollback below).
+      std::optional<nam_presets::PresetData> replaced;
+
+      if (mPresetManager.Add(preset) == nam_presets::PresetError::kDuplicateName)
+      {
+        const EMsgBoxResult result = _ShowMessageBox(
+          GetUI(), ("Overwrite preset \"" + name + "\"?").c_str(), "Preset already exists", kMB_YESNO);
+        if (result != kYES)
+          return true;
+
+        replaced = mPresetManager.Get(name);
+        mPresetManager.Remove(name);
+        mPresetManager.Add(preset); // Can't fail: the name was just removed.
+      }
+
+      if (mPresetManager.Save() != nam_presets::PresetError::kNone)
+      {
+        // Disk write failed: put the store back exactly as it was, so the preset list on
+        // screen never diverges from what's actually persisted. When overwriting, that
+        // means restoring the replaced preset, not just dropping the new one.
+        mPresetManager.Remove(name);
+        if (replaced)
+          mPresetManager.Add(*replaced);
+        _ShowMessageBox(GetUI(), "Failed to write presets file to disk.", "Failed to save preset!", kMB_OK);
+      }
+      else
+        _SetCurrentPresetName(name);
+      return true;
+    }
+    case kMsgTagDeletePreset:
+    {
+      const std::string name(reinterpret_cast<const char*>(pData));
+      const EMsgBoxResult result =
+        _ShowMessageBox(GetUI(), ("Delete preset \"" + name + "\"?").c_str(), "Delete preset?", kMB_YESNO);
+      if (result == kYES)
+      {
+        const std::optional<nam_presets::PresetData> removed = mPresetManager.Get(name);
+        mPresetManager.Remove(name);
+        if (mPresetManager.Save() != nam_presets::PresetError::kNone)
+        {
+          // Disk write failed: roll back the in-memory removal so the preset list on
+          // screen never claims a preset is gone when it's still on disk.
+          if (removed)
+            mPresetManager.Add(*removed);
+          _ShowMessageBox(GetUI(), "Failed to write presets file to disk.", "Failed to delete preset!", kMB_OK);
+        }
+        else if (name == mCurrentPresetName.Get())
+          _SetCurrentPresetName("");
+      }
       return true;
     }
     default: return false;
@@ -740,6 +838,107 @@ void NeuralAmpModeler::_ApplySlimParamToLoadedNAMs()
   };
   apply(mModel.get());
   apply(mStagedModel.get());
+}
+
+namespace
+{
+// Maps the EQ/volume params exposed by presets (issue #252) to the string keys
+// stored in PresetData::paramValues. Local to this translation unit: PresetManager
+// itself doesn't know about EParams.
+const std::map<EParams, std::string> kPresetParamNames = {
+  {kInputLevel, "InputLevel"},
+  {kOutputLevel, "OutputLevel"},
+  {kNoiseGateThreshold, "NoiseGateThreshold"},
+  {kNoiseGateActive, "NoiseGateActive"},
+  {kToneBass, "ToneBass"},
+  {kToneMid, "ToneMid"},
+  {kToneTreble, "ToneTreble"},
+  {kEQActive, "EQActive"},
+};
+} // namespace
+
+nam_presets::PresetData NeuralAmpModeler::_CollectCurrentState(const std::string& presetName) const
+{
+  nam_presets::PresetData preset;
+  preset.name = presetName;
+  preset.modelPath = mNAMPath.Get();
+  preset.irPath = mIRPath.Get();
+  for (const auto& [paramIdx, paramName] : kPresetParamNames)
+    preset.paramValues[paramName] = GetParam(paramIdx)->Value();
+  return preset;
+}
+
+void NeuralAmpModeler::_ApplyPreset(const nam_presets::PresetData& preset)
+{
+  for (const auto& [paramIdx, paramName] : kPresetParamNames)
+  {
+    const auto it = preset.paramValues.find(paramName);
+    if (it == preset.paramValues.end())
+      continue;
+    SetParameterValue(paramIdx, GetParam(paramIdx)->ToNormalized(it->second));
+  }
+  // SetParameterValue() updates the DSP-side value and informs the host, but doesn't push
+  // the new values to the knobs on screen (that's only needed when params change from code,
+  // as opposed to the user dragging a knob, which is why nothing else in this plugin needed it).
+  SendCurrentParamValuesFromDelegate();
+
+  if (preset.modelPath.size())
+  {
+    const WDL_String modelPath(preset.modelPath.c_str());
+    const std::string msg = _StageModel(modelPath);
+    if (msg.size())
+    {
+      std::stringstream ss;
+      ss << "Failed to load NAM model from preset. Message:\n\n" << msg;
+      _ShowMessageBox(GetUI(), ss.str().c_str(), "Failed to load model!", kMB_OK);
+    }
+    else if (GetUI() != nullptr)
+    {
+      SendControlMsgFromDelegate(kCtrlTagModelFileBrowser, kMsgTagLoadedModel, mNAMPath.GetLength(), mNAMPath.Get());
+    }
+  }
+  else
+  {
+    // The preset was saved without a model, so it means "no model": unload whatever is
+    // loaded rather than leaving it behind. _ApplyDSPStaging picks the flag up on the
+    // audio thread, same as the browser's clear button does.
+    mShouldRemoveModel = true;
+    if (GetUI() != nullptr)
+      SendControlMsgFromDelegate(kCtrlTagModelFileBrowser, kMsgTagClearedFile, 0, nullptr);
+  }
+
+  if (preset.irPath.size())
+  {
+    const WDL_String irPath(preset.irPath.c_str());
+    const dsp::wav::LoadReturnCode retCode = _StageIR(irPath);
+    if (retCode != dsp::wav::LoadReturnCode::SUCCESS)
+    {
+      std::stringstream message;
+      message << "Failed to load IR file " << preset.irPath << " from preset:\n";
+      message << dsp::wav::GetMsgForLoadReturnCode(retCode);
+      _ShowMessageBox(GetUI(), message.str().c_str(), "Failed to load IR!", kMB_OK);
+    }
+    else if (GetUI() != nullptr)
+    {
+      SendControlMsgFromDelegate(kCtrlTagIRFileBrowser, kMsgTagLoadedIR, mIRPath.GetLength(), mIRPath.Get());
+    }
+  }
+  else
+  {
+    // Likewise for the IR: an empty path in the preset means "no IR", not "leave it alone".
+    mShouldRemoveIR = true;
+    if (GetUI() != nullptr)
+      SendControlMsgFromDelegate(kCtrlTagIRFileBrowser, kMsgTagClearedFile, 0, nullptr);
+  }
+}
+
+void NeuralAmpModeler::_SetCurrentPresetName(const std::string& name)
+{
+  mCurrentPresetName.Set(name.c_str());
+
+  if (GetUI() != nullptr)
+    SendControlMsgFromDelegate(
+      kCtrlTagPresetControl, kMsgTagPresetNameChanged, mCurrentPresetName.GetLength(), mCurrentPresetName.Get());
 }
 
 std::string NeuralAmpModeler::_StageModel(const WDL_String& modelPath)

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -624,8 +624,8 @@ bool NeuralAmpModeler::OnMessage(int msgTag, int ctrlTag, int dataSize, const vo
 
       if (mPresetManager.Add(preset) == nam_presets::PresetError::kDuplicateName)
       {
-        const EMsgBoxResult result = _ShowMessageBox(
-          GetUI(), ("Overwrite preset \"" + name + "\"?").c_str(), "Preset already exists", kMB_YESNO);
+        const EMsgBoxResult result =
+          _ShowMessageBox(GetUI(), ("Overwrite preset \"" + name + "\"?").c_str(), "Preset already exists", kMB_YESNO);
         if (result != kYES)
           return true;
 
@@ -846,14 +846,9 @@ namespace
 // stored in PresetData::paramValues. Local to this translation unit: PresetManager
 // itself doesn't know about EParams.
 const std::map<EParams, std::string> kPresetParamNames = {
-  {kInputLevel, "InputLevel"},
-  {kOutputLevel, "OutputLevel"},
-  {kNoiseGateThreshold, "NoiseGateThreshold"},
-  {kNoiseGateActive, "NoiseGateActive"},
-  {kToneBass, "ToneBass"},
-  {kToneMid, "ToneMid"},
-  {kToneTreble, "ToneTreble"},
-  {kEQActive, "EQActive"},
+  {kInputLevel, "InputLevel"},           {kOutputLevel, "OutputLevel"}, {kNoiseGateThreshold, "NoiseGateThreshold"},
+  {kNoiseGateActive, "NoiseGateActive"}, {kToneBass, "ToneBass"},       {kToneMid, "ToneMid"},
+  {kToneTreble, "ToneTreble"},           {kEQActive, "EQActive"},
 };
 } // namespace
 

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -9,6 +9,7 @@
 #include "../NeuralAmpModelerCore/NAM/slimmable.h"
 
 #include "Colors.h"
+#include "PresetManager.h"
 #include "ToneStack.h"
 
 #include "IPlug_include_in_plug_hdr.h"
@@ -65,6 +66,7 @@ enum ECtrlTags
   kCtrlTagSlimmableIcon,
   kCtrlTagSlimOverlayBackdrop,
   kCtrlTagSlimKnob,
+  kCtrlTagPresetControl,
   kNumCtrlTags
 };
 
@@ -74,10 +76,20 @@ enum EMsgTags
   kMsgTagClearModel = 0,
   kMsgTagClearIR,
   kMsgTagHighlightColor,
+  // Presets (issue #252): pData is a null-terminated preset name string.
+  kMsgTagLoadPreset,
+  kMsgTagSavePreset,
+  kMsgTagDeletePreset,
   // The following tags are from DSP -> UI
   kMsgTagLoadFailed,
   kMsgTagLoadedModel,
   kMsgTagLoadedIR,
+  // Presets: pData is the current preset name, or dataSize == 0 if none (reset to default label).
+  kMsgTagPresetNameChanged,
+  // Presets: a preset was applied that has no model/IR, so the DSP unloaded the current one
+  // and the file browser must reset to its default label. No payload: the control tag it's
+  // sent to says which browser is meant.
+  kMsgTagClearedFile,
   kNumMsgTags
 };
 
@@ -212,6 +224,9 @@ public:
   void OnParamChangeUI(int paramIdx, iplug::EParamSource source) override;
   bool OnMessage(int msgTag, int ctrlTag, int dataSize, const void* pData) override;
 
+  // Read-only: names of presets currently in the local preset store, for the UI to build its menu.
+  std::vector<std::string> GetPresetNames() const { return mPresetManager.ListNames(); }
+
 private:
   // Allocates mInputPointers and mOutputPointers
   void _AllocateIOPointers(const size_t nChans);
@@ -256,6 +271,14 @@ private:
   void _SetInputGain();
   void _SetOutputGain();
   void _ApplySlimParamToLoadedNAMs();
+
+  // Presets: build a PresetData snapshot from the current model/IR/EQ/volume state,
+  // or push a PresetData's model/IR/EQ/volume state into the plugin.
+  nam_presets::PresetData _CollectCurrentState(const std::string& presetName) const;
+  void _ApplyPreset(const nam_presets::PresetData& preset);
+  // Updates mCurrentPresetName and, if the UI is open, pushes it to the preset button's
+  // label. Pass an empty name to reset the button back to its default label.
+  void _SetCurrentPresetName(const std::string& name);
 
   // See: Unserialization.cpp
   void _UnserializeApplyConfig(nlohmann::json& config);
@@ -318,6 +341,12 @@ private:
   WDL_String mNAMPath;
   // Path to IR (.wav file)
   WDL_String mIRPath;
+
+  // Local preset store (issue #252 / #428). Lives outside host/DAW state.
+  nam_presets::PresetManager mPresetManager;
+  // Name of the preset currently loaded/saved, for display only. Session-scoped:
+  // not part of host-serialized state (Unserialization.cpp is untouched by design).
+  WDL_String mCurrentPresetName;
 
   WDL_String mHighLightColor{PluginColors::NAM_THEMECOLOR.ToColorCode()};
 

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -292,11 +292,11 @@ public:
     if (mPresetNames.size())
     {
       mMenu.AddSeparator();
-      for (int i = 0; i < (int) mPresetNames.size(); i++)
+      for (int i = 0; i < (int)mPresetNames.size(); i++)
         mMenu.AddItem(new IPopupMenu::Item(mPresetNames[i].c_str(), IPopupMenu::Item::kNoFlags, i));
 
       auto* pDeleteMenu = new IPopupMenu();
-      for (int i = 0; i < (int) mPresetNames.size(); i++)
+      for (int i = 0; i < (int)mPresetNames.size(); i++)
         pDeleteMenu->AddItem(new IPopupMenu::Item(mPresetNames[i].c_str(), IPopupMenu::Item::kNoFlags, i));
       mMenu.AddItem("Delete preset", -1, pDeleteMenu); // mMenu's Item now owns pDeleteMenu
       mDeleteMenuPtr = pDeleteMenu;
@@ -321,7 +321,7 @@ public:
       if (tag >= 0 && static_cast<size_t>(tag) < mPresetNames.size())
       {
         const std::string& name = mPresetNames[tag];
-        GetDelegate()->SendArbitraryMsgFromUI(kMsgTagDeletePreset, kNoTag, (int) name.size() + 1, name.c_str());
+        GetDelegate()->SendArbitraryMsgFromUI(kMsgTagDeletePreset, kNoTag, (int)name.size() + 1, name.c_str());
       }
       return;
     }
@@ -333,14 +333,14 @@ public:
     else if (tag >= 0 && static_cast<size_t>(tag) < mPresetNames.size())
     {
       const std::string& name = mPresetNames[tag];
-      GetDelegate()->SendArbitraryMsgFromUI(kMsgTagLoadPreset, kNoTag, (int) name.size() + 1, name.c_str());
+      GetDelegate()->SendArbitraryMsgFromUI(kMsgTagLoadPreset, kNoTag, (int)name.size() + 1, name.c_str());
     }
   }
 
   void OnTextEntryCompletion(const char* str, int valIdx) override
   {
     if (str && str[0])
-      GetDelegate()->SendArbitraryMsgFromUI(kMsgTagSavePreset, kNoTag, (int) strlen(str) + 1, str);
+      GetDelegate()->SendArbitraryMsgFromUI(kMsgTagSavePreset, kNoTag, (int)strlen(str) + 1, str);
   }
 
   void OnMsgFromDelegate(int msgTag, int dataSize, const void* pData) override

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -2,8 +2,11 @@
 
 #include <cmath> // std::round
 #include <cstdio> // FILE, fclose
+#include <cstring> // strlen
 #include <sstream> // std::stringstream
+#include <string>
 #include <unordered_map> // std::unordered_map
+#include <vector>
 #include "IControls.h"
 #include "IPlugPaths.h"
 
@@ -261,6 +264,122 @@ public:
   }
 };
 
+// Presets button (issue #252): click opens a menu to load an existing preset, or
+// save the current model/IR/EQ/volume state as a new one. Message tags/handling
+// live in NeuralAmpModeler::OnMessage; this control only builds/reads the menu.
+class NAMPresetControl : public IVButtonControl
+{
+public:
+  NAMPresetControl(const IRECT& bounds, const IVStyle& style)
+  : IVButtonControl(bounds, DefaultClickActionFunc, kDefaultLabel, style)
+  {
+  }
+
+  // Called by the click handler with the current preset names, right before showing the menu.
+  void ShowMenu(std::vector<std::string> presetNames)
+  {
+    mPresetNames = std::move(presetNames);
+
+    // mMenu.Clear() destroys its previous Items, and an Item that owns a submenu
+    // (via std::unique_ptr<IPopupMenu>) deletes it on destruction. So the delete
+    // submenu must be heap-allocated with `new` here, freshly, every time -- it must
+    // never point at a member/stack IPopupMenu, or that delete is undefined behavior.
+    mMenu.Clear();
+    mDeleteMenuPtr = nullptr;
+
+    mMenu.AddItem(new IPopupMenu::Item("Save current as preset...", IPopupMenu::Item::kNoFlags, kSaveTag));
+
+    if (mPresetNames.size())
+    {
+      mMenu.AddSeparator();
+      for (int i = 0; i < (int) mPresetNames.size(); i++)
+        mMenu.AddItem(new IPopupMenu::Item(mPresetNames[i].c_str(), IPopupMenu::Item::kNoFlags, i));
+
+      auto* pDeleteMenu = new IPopupMenu();
+      for (int i = 0; i < (int) mPresetNames.size(); i++)
+        pDeleteMenu->AddItem(new IPopupMenu::Item(mPresetNames[i].c_str(), IPopupMenu::Item::kNoFlags, i));
+      mMenu.AddItem("Delete preset", -1, pDeleteMenu); // mMenu's Item now owns pDeleteMenu
+      mDeleteMenuPtr = pDeleteMenu;
+    }
+
+    GetUI()->CreatePopupMenu(*this, mMenu, GetRECT());
+  }
+
+  void OnPopupMenuSelection(IPopupMenu* pSelectedMenu, int valIdx) override
+  {
+    if (pSelectedMenu == nullptr)
+      return;
+
+    IPopupMenu::Item* pItem = pSelectedMenu->GetChosenItem();
+    if (pItem == nullptr)
+      return;
+
+    const int tag = pItem->GetTag();
+
+    if (pSelectedMenu == mDeleteMenuPtr)
+    {
+      if (tag >= 0 && static_cast<size_t>(tag) < mPresetNames.size())
+      {
+        const std::string& name = mPresetNames[tag];
+        GetDelegate()->SendArbitraryMsgFromUI(kMsgTagDeletePreset, kNoTag, (int) name.size() + 1, name.c_str());
+      }
+      return;
+    }
+
+    if (tag == kSaveTag)
+    {
+      GetUI()->CreateTextEntry(*this, mText, GetRECT(), "");
+    }
+    else if (tag >= 0 && static_cast<size_t>(tag) < mPresetNames.size())
+    {
+      const std::string& name = mPresetNames[tag];
+      GetDelegate()->SendArbitraryMsgFromUI(kMsgTagLoadPreset, kNoTag, (int) name.size() + 1, name.c_str());
+    }
+  }
+
+  void OnTextEntryCompletion(const char* str, int valIdx) override
+  {
+    if (str && str[0])
+      GetDelegate()->SendArbitraryMsgFromUI(kMsgTagSavePreset, kNoTag, (int) strlen(str) + 1, str);
+  }
+
+  void OnMsgFromDelegate(int msgTag, int dataSize, const void* pData) override
+  {
+    if (msgTag != kMsgTagPresetNameChanged)
+      return;
+
+    if (dataSize > 0)
+    {
+      const char* name = reinterpret_cast<const char*>(pData);
+      SetLabelStr(TruncatedForLabel(name).c_str());
+      SetTooltip(name); // full name available on hover
+    }
+    else
+    {
+      SetLabelStr(kDefaultLabel);
+      SetTooltip("");
+    }
+  }
+
+private:
+  static std::string TruncatedForLabel(const std::string& name)
+  {
+    static constexpr size_t kMaxChars = 8;
+    if (name.size() <= kMaxChars)
+      return name;
+    return name.substr(0, kMaxChars) + "...";
+  }
+
+  static constexpr int kSaveTag = -1;
+  static constexpr const char* kDefaultLabel = "Presets";
+
+  IPopupMenu mMenu;
+  // Non-owning: owned by mMenu's "Delete preset" Item (its unique_ptr<IPopupMenu>).
+  // Only used to identify, in OnPopupMenuSelection, which menu the click came from.
+  IPopupMenu* mDeleteMenuPtr = nullptr;
+  std::vector<std::string> mPresetNames;
+};
+
 class NAMFileBrowserControl : public IDirBrowseControlBase
 {
 public:
@@ -451,6 +570,12 @@ public:
         SetBrowserState(NAMBrowserState::Loaded);
       }
       break;
+      case kMsgTagClearedFile:
+        // Same reset the clear button does locally, for when the DSP unloads the file on
+        // its own (applying a preset that has no model/IR).
+        mFileNameControl->SetLabelAndTooltip(mDefaultLabelStr.Get());
+        SetBrowserState(NAMBrowserState::Empty);
+        break;
       default: break;
     }
   }

--- a/NeuralAmpModeler/PresetManager.cpp
+++ b/NeuralAmpModeler/PresetManager.cpp
@@ -1,0 +1,174 @@
+#include "PresetManager.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <utility>
+
+#include "json.hpp"
+
+namespace nam_presets
+{
+
+namespace
+{
+namespace fs = std::filesystem;
+
+nlohmann::json PresetToJson(const PresetData& preset)
+{
+  nlohmann::json j;
+  j["modelPath"] = preset.modelPath;
+  j["irPath"] = preset.irPath;
+  j["params"] = preset.paramValues;
+  return j;
+}
+
+// false if the node isn't shaped as expected (that preset is skipped on load, doesn't abort the whole file).
+bool PresetFromJson(const std::string& name, const nlohmann::json& j, PresetData& outPreset)
+{
+  if (!j.is_object())
+    return false;
+
+  outPreset.name = name;
+  outPreset.modelPath = j.value("modelPath", "");
+  outPreset.irPath = j.value("irPath", "");
+  outPreset.paramValues.clear();
+
+  if (j.contains("params") && j.at("params").is_object())
+  {
+    for (auto it = j.at("params").begin(); it != j.at("params").end(); ++it)
+    {
+      if (it.value().is_number())
+        outPreset.paramValues[it.key()] = it.value().get<double>();
+    }
+  }
+  return true;
+}
+} // namespace
+
+PresetManager::PresetManager(std::string basePath)
+: mBasePath(std::move(basePath))
+, mPresetsFilePath(mBasePath + "/presets.json")
+{
+}
+
+PresetError PresetManager::Initialize()
+{
+  std::error_code ec;
+  fs::create_directories(mBasePath, ec);
+  if (ec)
+    return PresetError::kDirCreateFailed;
+
+  if (!fs::exists(mPresetsFilePath, ec))
+  {
+    std::ofstream out(mPresetsFilePath, std::ios::trunc);
+    if (!out.is_open())
+      return PresetError::kWriteFailed;
+    out << "{}";
+    if (!out.good())
+      return PresetError::kWriteFailed;
+  }
+  return PresetError::kNone;
+}
+
+PresetError PresetManager::Load()
+{
+  const PresetError initErr = Initialize();
+  if (initErr != PresetError::kNone)
+    return initErr;
+
+  std::ifstream in(mPresetsFilePath);
+  if (!in.is_open())
+    return PresetError::kFileNotFound;
+
+  std::stringstream buffer;
+  buffer << in.rdbuf();
+
+  nlohmann::json root;
+  try
+  {
+    root = nlohmann::json::parse(buffer.str());
+  }
+  catch (const nlohmann::json::exception&)
+  {
+    return PresetError::kParseError;
+  }
+
+  if (!root.is_object())
+    return PresetError::kParseError;
+
+  std::map<std::string, PresetData> loaded;
+  for (auto it = root.begin(); it != root.end(); ++it)
+  {
+    PresetData preset;
+    if (PresetFromJson(it.key(), it.value(), preset))
+      loaded[it.key()] = std::move(preset);
+  }
+
+  mPresets = std::move(loaded);
+  return PresetError::kNone;
+}
+
+PresetError PresetManager::Save() const
+{
+  nlohmann::json root = nlohmann::json::object();
+  for (const auto& [name, preset] : mPresets)
+    root[name] = PresetToJson(preset);
+
+  // Atomic write: write to a tmp file and rename it over the real file,
+  // so a crash mid-write never leaves presets.json corrupted.
+  const std::string tmpPath = mPresetsFilePath + ".tmp";
+  {
+    std::ofstream out(tmpPath, std::ios::trunc);
+    if (!out.is_open())
+      return PresetError::kWriteFailed;
+    out << root.dump(2);
+    if (!out.good())
+      return PresetError::kWriteFailed;
+  }
+
+  std::error_code ec;
+  fs::rename(tmpPath, mPresetsFilePath, ec);
+  if (ec)
+    return PresetError::kWriteFailed;
+
+  return PresetError::kNone;
+}
+
+PresetError PresetManager::Add(const PresetData& preset)
+{
+  if (mPresets.find(preset.name) != mPresets.end())
+    return PresetError::kDuplicateName;
+
+  mPresets[preset.name] = preset;
+  return PresetError::kNone;
+}
+
+PresetError PresetManager::Remove(const std::string& name)
+{
+  const auto it = mPresets.find(name);
+  if (it == mPresets.end())
+    return PresetError::kNotFound;
+
+  mPresets.erase(it);
+  return PresetError::kNone;
+}
+
+std::optional<PresetData> PresetManager::Get(const std::string& name) const
+{
+  const auto it = mPresets.find(name);
+  if (it == mPresets.end())
+    return std::nullopt;
+  return it->second;
+}
+
+std::vector<std::string> PresetManager::ListNames() const
+{
+  std::vector<std::string> names;
+  names.reserve(mPresets.size());
+  for (const auto& [name, preset] : mPresets)
+    names.push_back(name);
+  return names;
+}
+
+} // namespace nam_presets

--- a/NeuralAmpModeler/PresetManager.h
+++ b/NeuralAmpModeler/PresetManager.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace nam_presets
+{
+
+// Raw preset data. Agnostic of the plugin's param enum:
+// the caller (NeuralAmpModeler.cpp) maps kX <-> "paramName" when building/reading this.
+struct PresetData
+{
+  std::string name;
+  std::string modelPath; // .nam file, absolute
+  std::string irPath; // .wav file, absolute, may be empty (no IR)
+  std::map<std::string, double> paramValues; // "InputLevel" -> 0.5, etc.
+};
+
+enum class PresetError
+{
+  kNone,
+  kFileNotFound,
+  kParseError, // corrupt/invalid JSON
+  kDirCreateFailed,
+  kWriteFailed,
+  kDuplicateName,
+  kNotFound // preset requested by name doesn't exist
+};
+
+class PresetManager
+{
+public:
+  // basePath: ~/Library/Application Support/NeuralAmpModeler (via AppSupportPath).
+  // Injected, not hardcoded, so it can be tested with a temp dir.
+  explicit PresetManager(std::string basePath);
+
+  // Creates base directory + presets.json if they don't exist. Idempotent.
+  PresetError Initialize();
+
+  // Reads the whole store into memory (lazy, first call triggers Initialize()).
+  PresetError Load();
+
+  // Writes current in-memory state to disk (atomic write: tmp file + rename).
+  PresetError Save() const;
+
+  // In-memory CRUD. Doesn't touch disk until the next Save().
+  // Rejects if preset.name already exists (no overwrite) -> kDuplicateName.
+  // To replace an existing preset: Remove(name) + Add(preset).
+  PresetError Add(const PresetData& preset);
+  PresetError Remove(const std::string& name);
+  std::optional<PresetData> Get(const std::string& name) const;
+  std::vector<std::string> ListNames() const;
+
+private:
+  std::string mBasePath;
+  std::string mPresetsFilePath; // mBasePath + "/presets.json"
+  std::map<std::string, PresetData> mPresets;
+};
+
+} // namespace nam_presets

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj
@@ -334,6 +334,7 @@
     <ClInclude Include="..\Colors.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
     <ClInclude Include="..\NeuralAmpModelerControls.h" />
+    <ClInclude Include="..\PresetManager.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\activations.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\conv1d.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\convnet.h" />
@@ -398,6 +399,7 @@
     <ClCompile Include="..\..\AudioDSPTools\dsp\RecursiveLinearFilter.cpp" />
     <ClCompile Include="..\..\AudioDSPTools\dsp\wav.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
+    <ClCompile Include="..\PresetManager.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\activations.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\conv1d.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\convnet.cpp" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-app.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
+    <ClCompile Include="..\PresetManager.cpp" />
     <ClCompile Include="..\..\iPlug2\IGraphics\IControl.cpp">
       <Filter>IGraphics</Filter>
     </ClCompile>
@@ -117,6 +118,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\NeuralAmpModeler.h" />
+    <ClInclude Include="..\PresetManager.h" />
     <ClInclude Include="..\resources\resource.h">
       <Filter>resources</Filter>
     </ClInclude>

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj/project.pbxproj
@@ -472,6 +472,17 @@
 		B885CBC52304AE7300D73128 /* IPlugProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F8F61A8202807B9003F2573 /* IPlugProcessor.cpp */; };
 		B8E22A0C220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */; };
 		B8E22A0D220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */; };
+		C26CF4CE2FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4CF2FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D02FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D12FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D22FFD902F0069318D /* PresetManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C26CF4CC2FFD902F0069318D /* PresetManager.h */; };
+		C26CF4D32FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D42FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D52FFD902F0069318D /* PresetManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C26CF4CC2FFD902F0069318D /* PresetManager.h */; };
+		C26CF4D62FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D72FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
+		C26CF4D82FFD902F0069318D /* PresetManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C26CF4CD2FFD902F0069318D /* PresetManager.cpp */; };
 		C2A2FAE112D0000120027AB66 /* wavenet/a2_fast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2A2FAE012D0000110027AB66 /* wavenet/a2_fast.cpp */; };
 		C2A2FAE122D0000120027AB66 /* wavenet/a2_fast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2A2FAE012D0000110027AB66 /* wavenet/a2_fast.cpp */; };
 		C2A2FAE132D0000120027AB66 /* wavenet/a2_fast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2A2FAE012D0000110027AB66 /* wavenet/a2_fast.cpp */; };
@@ -1044,6 +1055,8 @@
 		B8E22A0A220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.cpp.cpp; name = IPlugVST3_ProcessorBase.cpp; path = ../../iPlug2/IPlug/VST3/IPlugVST3_ProcessorBase.cpp; sourceTree = "<group>"; tabWidth = 2; };
 		B8E22A0B220268C4007CBF4C /* IPlugVST3_ProcessorBase.h */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.h; name = IPlugVST3_ProcessorBase.h; path = ../../iPlug2/IPlug/VST3/IPlugVST3_ProcessorBase.h; sourceTree = "<group>"; tabWidth = 2; };
 		B8EA6B932203868500D23A86 /* IPlugVST3_Common.h */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.h; name = IPlugVST3_Common.h; path = ../../iPlug2/IPlug/VST3/IPlugVST3_Common.h; sourceTree = "<group>"; tabWidth = 2; };
+		C26CF4CC2FFD902F0069318D /* PresetManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../PresetManager.h; sourceTree = "<group>"; };
+		C26CF4CD2FFD902F0069318D /* PresetManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ../PresetManager.cpp; sourceTree = "<group>"; };
 		C2A2FAE012D0000110027AB66 /* wavenet/a2_fast.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = wavenet/a2_fast.cpp; sourceTree = "<group>"; };
 		C2A2FAE022D0000110027AB66 /* wavenet/a2_fast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wavenet/a2_fast.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1114,6 +1127,8 @@
 		089C166AFE841209C02AAC07 /* IPlugExample */ = {
 			isa = PBXGroup;
 			children = (
+				C26CF4CC2FFD902F0069318D /* PresetManager.h */,
+				C26CF4CD2FFD902F0069318D /* PresetManager.cpp */,
 				4F2FB1392A0047420027AB66 /* dsp */,
 				4F2FB1452A0047420027AB66 /* NAM */,
 				AA355E2C295B688F0061AA3D /* Colors.h */,
@@ -2018,6 +2033,7 @@
 				AAB7BBB72CC4B8C6000B8B6E /* get_dsp.h in Headers */,
 				4F2FB1902A0047430027AB66 /* version.h in Headers */,
 				AA7C86002B439AC000B5FB3A /* ptrlist.h in Headers */,
+				C26CF4D52FFD902F0069318D /* PresetManager.h in Headers */,
 				4F4856852773C3B5005BCF8E /* IPlugAUViewController.h in Headers */,
 				AA7C85FC2B439AC000B5FB3A /* _LanczosResampler.h in Headers */,
 				4F2FB17C2A0047430027AB66 /* ImpulseResponse.h in Headers */,
@@ -2048,6 +2064,7 @@
 				4F03A5D420A4621100EBDFFB /* IGraphicsUtilities.h in Headers */,
 				AA7C85FF2B439AC000B5FB3A /* ptrlist.h in Headers */,
 				4F03A5AA20A4621100EBDFFB /* IGraphicsLiveEdit.h in Headers */,
+				C26CF4D22FFD902F0069318D /* PresetManager.h in Headers */,
 				4F6369EA20A466470022C370 /* IControl.h in Headers */,
 				4F03A5D520A4621100EBDFFB /* IGraphicsConstants.h in Headers */,
 				4FF3205820B2BFAB00269268 /* IPlugPaths.h in Headers */,
@@ -2572,6 +2589,7 @@
 				4F2FB1842A0047430027AB66 /* wav.cpp in Sources */,
 				4F2FB1C12A0047430027AB66 /* wavenet/model.cpp in Sources */,
 				B1D2F7072D0000020027AB66 /* wavenet/slimmable.cpp in Sources */,
+				C26CF4D72FFD902F0069318D /* PresetManager.cpp in Sources */,
 				C2A2FAE112D0000120027AB66 /* wavenet/a2_fast.cpp in Sources */,
 				AAB7E0122CC4B8C6000B8B6E /* container.cpp in Sources */,
 				4F2FB1CF2A0047430027AB66 /* conv1d.cpp in Sources */,
@@ -2625,6 +2643,7 @@
 				4FD52136202A5BD000A4D22A /* dfx-au-utilities.c in Sources */,
 				4F7C4960255DDFC500DF7588 /* ITextEntryControl.cpp in Sources */,
 				4F5F344420C0226200487201 /* IPlugPaths.mm in Sources */,
+				C26CF4D02FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F2FB1752A0047430027AB66 /* ImpulseResponse.cpp in Sources */,
 				4F7C495E255DDFC500DF7588 /* IControls.cpp in Sources */,
 				4F35DEB0207E5C5A00867D8F /* IPlugPluginBase.cpp in Sources */,
@@ -2679,6 +2698,7 @@
 				4F3EE1DB231438D000004786 /* IPlugAPP_main.cpp in Sources */,
 				4F2FB1682A0047430027AB66 /* dsp.cpp in Sources */,
 				4F3EE1DD231438D000004786 /* IGraphicsMac.mm in Sources */,
+				C26CF4CE2FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F3EE1DE231438D000004786 /* NeuralAmpModeler.cpp in Sources */,
 				4F2FB1A42A0047430027AB66 /* convnet.cpp in Sources */,
 				4F3EE1E0231438D000004786 /* IPlugAPIBase.cpp in Sources */,
@@ -2722,6 +2742,7 @@
 				4F2FB1982A0047430027AB66 /* dsp.cpp in Sources */,
 				AA341E252B9E5A530069C260 /* ToneStack.cpp in Sources */,
 				4F78BE2522E7406D00AD537E /* IPlugPluginBase.cpp in Sources */,
+				C26CF4D62FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F2FB1C22A0047430027AB66 /* wavenet/model.cpp in Sources */,
 				B1D2F7082D0000020027AB66 /* wavenet/slimmable.cpp in Sources */,
 				C2A2FAE142D0000120027AB66 /* wavenet/a2_fast.cpp in Sources */,
@@ -2744,6 +2765,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C26CF4D42FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F81597C205D50EB00393585 /* baseiids.cpp in Sources */,
 				4FDAC0EC207D76C600299363 /* IPlugTimer.cpp in Sources */,
 				4F7C495D255DDFC400DF7588 /* ITextEntryControl.cpp in Sources */,
@@ -2842,6 +2864,7 @@
 				4F2FB1952A0047430027AB66 /* dsp.cpp in Sources */,
 				AA341E212B9E5A530069C260 /* ToneStack.cpp in Sources */,
 				4FB600231567CB0A0020189A /* IPlugParameter.cpp in Sources */,
+				C26CF4D12FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F2FB1BF2A0047430027AB66 /* wavenet/model.cpp in Sources */,
 				B1D2F7052D0000020027AB66 /* wavenet/slimmable.cpp in Sources */,
 				C2A2FAE162D0000120027AB66 /* wavenet/a2_fast.cpp in Sources */,
@@ -2864,6 +2887,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C26CF4D32FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F7C4964255DDFC800DF7588 /* IControls.cpp in Sources */,
 				4F03A5B220A4621100EBDFFB /* IGraphics.cpp in Sources */,
 				4F7C4966255DDFC800DF7588 /* ITextEntryControl.cpp in Sources */,
@@ -2927,6 +2951,7 @@
 				4F690C9B203A345100A4A13E /* IPlugAPP_main.cpp in Sources */,
 				4F2FB1602A0047430027AB66 /* dsp.cpp in Sources */,
 				4FB1F58920E4B004004157C8 /* IGraphicsMac.mm in Sources */,
+				C26CF4D82FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4F3862EF2014BBEC0009F402 /* NeuralAmpModeler.cpp in Sources */,
 				4F2FB19C2A0047430027AB66 /* convnet.cpp in Sources */,
 				4F78D90B13B63BA50032E0F3 /* IPlugAPIBase.cpp in Sources */,
@@ -2956,6 +2981,7 @@
 				4FFBB90820863B0E00DDD0E7 /* pluginfactory.cpp in Sources */,
 				4FFBB90920863B0E00DDD0E7 /* vstinitiids.cpp in Sources */,
 				4FFBB90A20863B0E00DDD0E7 /* fdebug.cpp in Sources */,
+				C26CF4CF2FFD902F0069318D /* PresetManager.cpp in Sources */,
 				4FFBB90C20863B0E00DDD0E7 /* IPlugAPIBase.cpp in Sources */,
 				B8E22A0D220268C4007CBF4C /* IPlugVST3_ProcessorBase.cpp in Sources */,
 				4FFBB90D20863B0E00DDD0E7 /* fdynlib.cpp in Sources */,

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj
@@ -343,6 +343,7 @@
     <ClInclude Include="..\Colors.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
     <ClInclude Include="..\NeuralAmpModelerControls.h" />
+    <ClInclude Include="..\PresetManager.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\activations.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\conv1d.h" />
     <ClInclude Include="..\..\NeuralAmpModelerCore\NAM\convnet.h" />
@@ -426,6 +427,7 @@
     <ClCompile Include="..\..\AudioDSPTools\dsp\RecursiveLinearFilter.cpp" />
     <ClCompile Include="..\..\AudioDSPTools\dsp\wav.cpp" />
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
+    <ClCompile Include="..\PresetManager.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\activations.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\conv1d.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\convnet.cpp" />

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj.filters
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-vst3.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\NeuralAmpModeler.cpp" />
+    <ClCompile Include="..\PresetManager.cpp" />
     <ClCompile Include="..\..\iPlug2\IGraphics\IGraphics.cpp">
       <Filter>IGraphics</Filter>
     </ClCompile>
@@ -175,6 +176,7 @@
   <ItemGroup>
     <ClInclude Include="../config.h" />
     <ClInclude Include="..\NeuralAmpModeler.h" />
+    <ClInclude Include="..\PresetManager.h" />
     <ClInclude Include="..\resources\resource.h">
       <Filter>resources</Filter>
     </ClInclude>


### PR DESCRIPTION
## Summary

Adds a local preset system that lets users save and recall the current model, IR,
and EQ/volume settings under a named preset.

Closes #252
Closes #428

## Motivation

#252 asked for a way to group model, IR, and EQ/volume params under a named
preset that can be saved and recalled. #428 asked for a generic local
persistence layer (JSON file under the app's Application Support / AppData
path) as infrastructure for exactly this kind of feature, plus others
mentioned in that issue (default paths, one-time messages) that this PR
doesn't attempt to solve.

## Design decisions

- **Local JSON storage, not VST3's native preset system.** The plugin also
  ships as a standalone app, where VST3 native presets don't apply, so a
  self-contained format made more sense than coupling to the host's preset
  mechanism.
- **`PresetManager` is fully decoupled from `NeuralAmpModeler`.** It's a new,
  self-contained class that only knows about a plain `PresetData` struct
  (name, model path, IR path, and a param name -> value map) — it doesn't
  include `NeuralAmpModeler.h` or know about the parameter enum. Integration
  in `NeuralAmpModeler.cpp` is limited to two private methods
  (`CollectCurrentState()` / `ApplyPreset()`) that translate between the
  plugin's live state and `PresetData`, using the existing
  `GetParam()->Value()` / `SetParamValue()` API.
- **Storage location**: `presets.json` under `AppSupportPath()` (existing
  WDL/iPlug2 helper), so path resolution is already cross-platform without
  extra code.
- **Existing dependency reused**: uses `nlohmann::json`, already vendored in
  the repo — no new dependency added.
- **`Unserialization.cpp` is untouched.** That file handles state the host
  serializes into the DAW project, which is a separate concern from this
  local persistence layer.
- The UI control follows the same message-passing pattern
  (`SendArbitraryMsgFromUI` / message tags) already used elsewhere in
  `NeuralAmpModeler.cpp`, rather than introducing a new pattern.

## What's included

- Save / load / delete named presets (model, IR, EQ params, volume params)
- Duplicate name handling (replaces existing preset with the same name)
- Atomic writes with in-memory rollback if a disk write fails
- Cross-platform: updated both the macOS `.xcodeproj` and the Windows
  `.vcxproj` (`app` and `vst3` targets) to include the new files

## What's intentionally out of scope

- **AAX target** wasn't updated — I don't have the Avid SDK to build/verify
  it, so I left `NeuralAmpModeler-aax.vcxproj` untouched rather than guess.
  Happy to add it if someone can verify the AAX build.
- **Other #428 use cases** (default model/IR paths, one-time messages) — the
  storage format could be extended for these later, but this PR only
  implements what's needed for presets.
- No unit tests yet for `PresetManager` — it's designed to be testable in
  isolation (the base path is injected via constructor), so this could be a
  quick follow-up if useful.

## Testing

- Compiles clean on macOS (Xcode) and Windows.
- Manually verified end-to-end on both platforms: save a preset, close the
  plugin/app, reopen, load the preset, confirm model/IR/EQ/volume values are
  restored correctly.
- Ran the VST3 SDK Validator against the compiled `.vst3` on **Windows**:
  47/47 tests passed, no new/removed/renamed parameters detected.
- Haven't been able to run the Validator on **macOS** yet — I don't have
  access to a Mac at the moment. The macOS build was compiled and manually
  tested as noted above, just not run through the formal validator. Happy to
  do that once I have access again, or if CI already covers it, that works
  too.

<img width="695" height="541" alt="NAM" src="https://github.com/user-attachments/assets/e18de1e5-980f-4fb8-9aa7-faf2c58423ac" />


## PR Checklist
- [x] Did you format your code using [`forrmat.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [x] Windows
  - [ ] macOS
- [ ] Does your PR add, remove, or rename any plugin parameters? If yes...
  - [ ] Have you ensured that the plug-in unserializes correctly?
  - [ ] Have you ensured that _older_ versions of the plug-in load correctly? (See [`Unserialization.cpp`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/Unserialization.cpp).)
- [ ] Does your PR add or remove any graphical assets? If yes, are they defined in [config.h](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/config.h) and added in the two required locations in [main.rc](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/NeuralAmpModeler/resources/main.rc)?mat.bash`]
  
