### PR TITLE
[BREAKING] Add error displays for trouble loading model files

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -25,6 +25,12 @@ enum class NAMBrowserState
   Loaded // when file loaded, show "Clear" button
 };
 
+enum class NAMFileLoadSource
+{
+  ExistingBrowserSelection,
+  FilePickerSelection
+};
+
 // Where the corner button on the plugin (settings, close settings) goes
 // :param rect: Rect for the whole plugin's UI
 IRECT CornerButtonArea(const IRECT& rect)
@@ -297,7 +303,7 @@ public:
       if (pItem)
       {
         mSelectedItemIndex = mItems.Find(pItem);
-        LoadFileAtCurrentIndex();
+        LoadFileAtCurrentIndex(NAMFileLoadSource::ExistingBrowserSelection);
       }
     }
   }
@@ -313,7 +319,7 @@ public:
       if (mSelectedItemIndex < 0)
         mSelectedItemIndex = nItems - 1;
 
-      LoadFileAtCurrentIndex();
+      LoadFileAtCurrentIndex(NAMFileLoadSource::ExistingBrowserSelection);
     };
 
     auto nextFileFunc = [&](IControl* pCaller) {
@@ -325,7 +331,7 @@ public:
       if (mSelectedItemIndex >= nItems)
         mSelectedItemIndex = 0;
 
-      LoadFileAtCurrentIndex();
+      LoadFileAtCurrentIndex(NAMFileLoadSource::ExistingBrowserSelection);
     };
 
     auto loadFileFunc = [&](IControl* pCaller) {
@@ -340,7 +346,7 @@ public:
           AddPath(path.Get(), "");
           SetupMenu();
           SelectFirstFile();
-          LoadFileAtCurrentIndex();
+          LoadFileAtCurrentIndex(NAMFileLoadSource::ExistingBrowserSelection);
         }
       });
 #else
@@ -352,8 +358,7 @@ public:
             AddPath(path.Get(), "");
             SetupMenu();
             SetSelectedFile(fileName.Get());
-            if (!LoadFileAtCurrentIndex())
-              ReportDirectoryScanFailure(fileName, path);
+            LoadFileAtCurrentIndex(NAMFileLoadSource::FilePickerSelection, &fileName, &path);
           }
         });
 #endif
@@ -413,18 +418,26 @@ public:
     SetBrowserState(NAMBrowserState::Empty);
   }
 
-  bool LoadFileAtCurrentIndex()
+  void LoadFileAtCurrentIndex(NAMFileLoadSource source, const WDL_String* filePickerFileName = nullptr,
+                              const WDL_String* filePickerPath = nullptr)
   {
-    if (mSelectedItemIndex > -1 && mSelectedItemIndex < NItems())
+    if (source == NAMFileLoadSource::FilePickerSelection && mSelectedItemIndex == -1 &&
+        filePickerFileName != nullptr && filePickerPath != nullptr)
     {
-      WDL_String fileName, path;
-      GetSelectedFile(fileName);
-      mFileNameControl->SetLabelAndTooltipEllipsizing(fileName);
-      mCompletionHandlerFunc(fileName, path);
-      return true;
+      ReportDirectoryScanFailure(*filePickerFileName, *filePickerPath);
+      return;
     }
 
-    return false;
+    if (mSelectedItemIndex < 0 || mSelectedItemIndex >= NItems())
+    {
+      ReportUnexpectedLoadFailure(source, filePickerFileName);
+      return;
+    }
+
+    WDL_String fileName, path;
+    GetSelectedFile(fileName);
+    mFileNameControl->SetLabelAndTooltipEllipsizing(fileName);
+    mCompletionHandlerFunc(fileName, path);
   }
 
   void OnMsgFromDelegate(int msgTag, int dataSize, const void* pData) override
@@ -472,7 +485,24 @@ private:
     mFileNameControl->SetLabelStr(label.c_str());
     mFileNameControl->SetTooltip(message.str().c_str());
     SetBrowserState(NAMBrowserState::Empty);
-    std::fprintf(stderr, "NAM: %s\n", message.str().c_str());
+    std::fprintf(stderr, "NAM: File picker selection produced index -1. %s\n", message.str().c_str());
+  }
+
+  void ReportUnexpectedLoadFailure(NAMFileLoadSource source, const WDL_String* filePickerFileName)
+  {
+    if (filePickerFileName != nullptr)
+      mFileNameControl->SetLabelAndTooltipEllipsizing(*filePickerFileName);
+
+    const std::string label = std::string("(FAILED) ") + mFileNameControl->GetLabelStr();
+    const std::string message = "The selected file could not be loaded because the file browser encountered an "
+                                "unexpected selection state. Please select the file again.";
+
+    mFileNameControl->SetLabelStr(label.c_str());
+    mFileNameControl->SetTooltip(message.c_str());
+    SetBrowserState(NAMBrowserState::Empty);
+    std::fprintf(stderr, "NAM: %s Source: %s; selected index: %d; item count: %d.\n", message.c_str(),
+                 source == NAMFileLoadSource::FilePickerSelection ? "file picker" : "existing browser selection",
+                 mSelectedItemIndex, NItems());
   }
 
   void SelectFirstFile() { mSelectedItemIndex = mFiles.GetSize() ? 0 : -1; }

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -421,8 +421,8 @@ public:
   void LoadFileAtCurrentIndex(NAMFileLoadSource source, const WDL_String* filePickerFileName = nullptr,
                               const WDL_String* filePickerPath = nullptr)
   {
-    if (source == NAMFileLoadSource::FilePickerSelection && mSelectedItemIndex == -1 &&
-        filePickerFileName != nullptr && filePickerPath != nullptr)
+    if (source == NAMFileLoadSource::FilePickerSelection && mSelectedItemIndex == -1 && filePickerFileName != nullptr
+        && filePickerPath != nullptr)
     {
       ReportDirectoryScanFailure(*filePickerFileName, *filePickerPath);
       return;
@@ -494,8 +494,9 @@ private:
       mFileNameControl->SetLabelAndTooltipEllipsizing(*filePickerFileName);
 
     const std::string label = std::string("(FAILED) ") + mFileNameControl->GetLabelStr();
-    const std::string message = "The selected file could not be loaded because the file browser encountered an "
-                                "unexpected selection state. Please select the file again.";
+    const std::string message =
+      "The selected file could not be loaded because the file browser encountered an "
+      "unexpected selection state. Please select the file again.";
 
     mFileNameControl->SetLabelStr(label.c_str());
     mFileNameControl->SetTooltip(message.c_str());

--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -352,7 +352,8 @@ public:
             AddPath(path.Get(), "");
             SetupMenu();
             SetSelectedFile(fileName.Get());
-            LoadFileAtCurrentIndex();
+            if (!LoadFileAtCurrentIndex())
+              ReportDirectoryScanFailure(fileName, path);
           }
         });
 #endif
@@ -412,7 +413,7 @@ public:
     SetBrowserState(NAMBrowserState::Empty);
   }
 
-  void LoadFileAtCurrentIndex()
+  bool LoadFileAtCurrentIndex()
   {
     if (mSelectedItemIndex > -1 && mSelectedItemIndex < NItems())
     {
@@ -420,7 +421,10 @@ public:
       GetSelectedFile(fileName);
       mFileNameControl->SetLabelAndTooltipEllipsizing(fileName);
       mCompletionHandlerFunc(fileName, path);
+      return true;
     }
+
+    return false;
   }
 
   void OnMsgFromDelegate(int msgTag, int dataSize, const void* pData) override
@@ -456,6 +460,21 @@ public:
   }
 
 private:
+  void ReportDirectoryScanFailure(const WDL_String& fileName, const WDL_String& path)
+  {
+    mFileNameControl->SetLabelAndTooltipEllipsizing(fileName);
+    const std::string label = std::string("(FAILED) ") + mFileNameControl->GetLabelStr();
+
+    std::stringstream message;
+    message << "The selected file '" << fileName.Get() << "' was not found after scanning directory '" << path.Get()
+            << "'. The host may not have granted permission to enumerate that directory.";
+
+    mFileNameControl->SetLabelStr(label.c_str());
+    mFileNameControl->SetTooltip(message.str().c_str());
+    SetBrowserState(NAMBrowserState::Empty);
+    std::fprintf(stderr, "NAM: %s\n", message.str().c_str());
+  }
+
   void SelectFirstFile() { mSelectedItemIndex = mFiles.GetSize() ? 0 : -1; }
 
   void GetSelectedFileDirectory(WDL_String& path)


### PR DESCRIPTION
## Description
Related to #663, will provide more insight on what's going wrong and possibly alert users on how to find a workaround (i.e. place files in a place macOS can grant permission to).

This doesn't resolve the Issue, but should help give information in general.

Breaking change--signature of `LoadFileAtCurrentIndex()` is altered.

## PR Checklist
- [x] Did you format your code using [`format.bash`](https://github.com/sdatkinson/NeuralAmpModelerPlugin/blob/main/format.bash)?
- [ ] Does the VST3 plugin pass all of the unit tests in the [VST3PluginTestHost](https://steinbergmedia.github.io/vst3_dev_portal/pages/What+is+the+VST+3+SDK/Plug-in+Test+Host.html)? (Download it as part of the VST3 SDK [here](https://www.steinberg.net/developers/).)
  - [ ] Windows
  - [ ] macOS
- [N] Does your PR add, remove, or rename any plugin parameters?
- [N] Does your PR add or remove any graphical assets?
 
---

in more detail...

## Summary

- Make file loading explicitly distinguish between files selected through the file picker and existing browser selections used by the arrows or menu.
- Detect the Issue #663 symptom where a file-picker selection leaves the selected index at `-1`.
- Show a visible `(FAILED)` state with a specific directory-enumeration explanation for that case.
- Report other invalid browser-selection states with a generic error instead of incorrectly attributing them to directory permissions.
- Log the load source, selected index, and item count to aid future diagnosis.

This does not attempt to bypass macOS permissions. It prevents a suspected parent-directory scan failure from being silently ignored and distinguishes it from unrelated browser-navigation failures.

## Verification

- Built the universal Debug AU successfully for arm64 and x86_64:

  `xcodebuild -project NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj -target AU -configuration Debug -xcconfig NeuralAmpModeler/config/NeuralAmpModeler-mac.xcconfig CODE_SIGNING_ALLOWED=NO build`

- Reproduced the original silent behavior in Logic Pro 12.3 with known-good `.nam` and `.wav` files whose exact paths were readable but whose parent directory could not be enumerated.
- Confirmed that the compiled AU contains both the specific file-picker/index-`-1` diagnostic and the generic unexpected-selection diagnostic.