### PR TITLE
Default the Windows standalone app to ASIO

### DIFF
--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -56,6 +56,10 @@
 #define APP_COPY_AUV3 0
 #define APP_SIGNAL_VECTOR_SIZE 64
 
+#if defined APP_API && defined _WIN32
+  #define APP_DEFAULT_AUDIO_DRIVER 1 // ASIO
+#endif
+
 #define ROBOTO_FN "Roboto-Regular.ttf"
 #define MICHROMA_FN "Michroma-Regular.ttf"
 


### PR DESCRIPTION
## Summary
- default new Windows standalone settings to ASIO instead of DirectSound
- update the pinned iPlug2 host so applications can select a platform-specific default without changing other standalone apps
- continue honoring explicit `driver` values already present in `settings.ini`

## Dependency
- sdatkinson/iPlug2#17 adds the configurable standalone-driver default used here

## Tests
- confirmed preprocessing with `APP_API` and `_WIN32` defines `APP_DEFAULT_AUDIO_DRIVER` as `1`
- confirmed macOS preprocessing does not override the framework default
- `xcodebuild -workspace NeuralAmpModeler/NeuralAmpModeler.xcworkspace -scheme macOS-APP -configuration Debug -derivedDataPath /tmp/nam-issue-655-derived CODE_SIGNING_ALLOWED=NO build`
- GitHub Actions `Build Native`: Windows and macOS jobs passed

Resolves #655
