### PR TITLE
[BUGFIX] Fix IR loading from emoji paths on Windows

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -796,8 +796,7 @@ dsp::wav::LoadReturnCode NeuralAmpModeler::_StageIR(const WDL_String& irPath)
   dsp::wav::LoadReturnCode wavState = dsp::wav::LoadReturnCode::ERROR_OTHER;
   try
   {
-    auto irPathU8 = std::filesystem::u8path(irPath.Get());
-    mStagedIR = std::make_unique<dsp::ImpulseResponse>(irPathU8.string().c_str(), sampleRate);
+    mStagedIR = std::make_unique<dsp::ImpulseResponse>(irPath.Get(), sampleRate);
     wavState = mStagedIR->GetWavState();
   }
   catch (std::runtime_error& e)


### PR DESCRIPTION
## Summary
- preserve the UTF-8 IR filename received from iPlug2 instead of converting it back to a lossy narrow Windows path
- update AudioDSPTools so WAV files are opened through a native `std::filesystem::path`
- add coverage for loading a valid WAV from an emoji-named directory

## Tests
- `cmake --build AudioDSPTools/build/issue-641 -j4` (Release)
- `ctest --test-dir AudioDSPTools/build/issue-641 --output-on-failure`
- direct C++17 build and execution of `test_wav`

## Notes
- Uses AudioDSPTools v0.1.2, which contains the merged sdatkinson/AudioDSPTools#25 fix.
- The AudioDSPTools Debug build still encounters existing unrelated sign-comparison warnings promoted to errors in `Resample.h`; the Release build succeeds.

Resolves #641
