### PR TITLE
Fix Get NAM Models button mouse capture

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModelerControls.h
+++ b/NeuralAmpModeler/NeuralAmpModelerControls.h
@@ -259,7 +259,9 @@ public:
       bounds,
       [url](IControl* pCaller) {
         WDL_String fullURL(url);
-        pCaller->GetUI()->OpenURL(fullURL.Get());
+        auto* ui = pCaller->GetUI();
+        ui->ReleaseMouseCapture();
+        ui->OpenURL(fullURL.Get());
       },
       globeSVG)
   {


### PR DESCRIPTION
## Summary
- release the UI mouse capture before launching the external NAM models URL
- prevent subsequent clicks from remaining routed to the Get NAM Models button after returning to a Windows DAW

## Tests
- `git diff --check`
- `clang-format --dry-run --Werror NeuralAmpModeler/NeuralAmpModelerControls.h`
- `xcodebuild -project NeuralAmpModeler/projects/NeuralAmpModeler-macOS.xcodeproj -scheme macOS-APP -configuration Debug -derivedDataPath /tmp/nam-634-derived CODE_SIGNING_ALLOWED=NO build`
- Played around with it, seems to work as expected.

Resolves #634
