### PR TITLE
Default the Windows standalone app to ASIO

### DIFF
--- a/NeuralAmpModeler/config.h
+++ b/NeuralAmpModeler/config.h
@@ -56,6 +56,10 @@
 #define APP_COPY_AUV3 0
 #define APP_SIGNAL_VECTOR_SIZE 64
 
+#if defined APP_API && defined _WIN32
+  #define APP_DEFAULT_AUDIO_DRIVER 1 // ASIO
+#endif
+
 #define ROBOTO_FN "Roboto-Regular.ttf"
 #define MICHROMA_FN "Michroma-Regular.ttf"
 


### PR DESCRIPTION
## Summary
- default newly created Windows standalone settings to ASIO instead of DirectSound
- preserve explicit `driver` values in existing `settings.ini` files
- keep plug-in targets and non-Windows standalone builds on their existing defaults

## Dependency
- sdatkinson/iPlug2#18 adds the app-configurable standalone driver default used here

## Tests
- confirmed the focused preprocessing check failed before the change because no Windows standalone override existed
- confirmed Windows standalone preprocessing resolves `APP_DEFAULT_AUDIO_DRIVER` to `1` while Windows plug-in and non-Windows standalone configurations do not define an override
- built `NeuralAmpModeler-app` Release x64 with MSBuild
- `git diff --check`

The hardware-specific startup crash could not be reproduced locally without an affected DirectSound device configuration.

Resolves #655
